### PR TITLE
#28 [style] 공통 컴포넌트-pagetitle 및 상태 구분 탭 UI 구현

### DIFF
--- a/src/components/Common/PageTitle.tsx
+++ b/src/components/Common/PageTitle.tsx
@@ -1,10 +1,11 @@
+import { PageTitleProps } from '@/types/common/PageTitleProps';
 import { Heading } from '@chakra-ui/react';
 import React from 'react';
 
-const PageTitle = () => {
+const PageTitle: React.FC<PageTitleProps> = ({ pageTitle }) => {
     return (
         <Heading fontSize="1.5rem" fontWeight={600} className="mb-4">
-            마리모
+            {pageTitle}
         </Heading>
     );
 };

--- a/src/components/Common/PageTitle.tsx
+++ b/src/components/Common/PageTitle.tsx
@@ -1,0 +1,12 @@
+import { Heading } from '@chakra-ui/react';
+import React from 'react';
+
+const PageTitle = () => {
+    return (
+        <Heading fontSize="1.5rem" fontWeight={600} className="mb-4">
+            마리모
+        </Heading>
+    );
+};
+
+export default PageTitle;

--- a/src/components/Common/StateTab.tsx
+++ b/src/components/Common/StateTab.tsx
@@ -1,7 +1,8 @@
+import { StateTabProps } from '@/types/common/StateTabProps';
 import { Flex, Heading } from '@chakra-ui/react';
 import React from 'react';
 
-const StateTab = () => {
+const StateTab: React.FC<StateTabProps> = ({ tab1, tab2 }) => {
     return (
         <Flex>
             <Heading
@@ -9,14 +10,14 @@ const StateTab = () => {
                 fontWeight={500}
                 className="mr-4 hover:cursor-pointer"
             >
-                진행중
+                {tab1}
             </Heading>
             <Heading
                 fontSize="1.25rem"
                 fontWeight={500}
                 className="hover:cursor-pointer"
             >
-                완료
+                {tab2}
             </Heading>
         </Flex>
     );

--- a/src/components/Common/StateTab.tsx
+++ b/src/components/Common/StateTab.tsx
@@ -1,0 +1,25 @@
+import { Flex, Heading } from '@chakra-ui/react';
+import React from 'react';
+
+const StateTab = () => {
+    return (
+        <Flex>
+            <Heading
+                fontSize="1.25rem"
+                fontWeight={500}
+                className="mr-4 hover:cursor-pointer"
+            >
+                진행중
+            </Heading>
+            <Heading
+                fontSize="1.25rem"
+                fontWeight={500}
+                className="hover:cursor-pointer"
+            >
+                완료
+            </Heading>
+        </Flex>
+    );
+};
+
+export default StateTab;

--- a/src/types/common/PageTitleProps.ts
+++ b/src/types/common/PageTitleProps.ts
@@ -1,0 +1,3 @@
+export interface PageTitleProps {
+    pageTitle: string;
+}

--- a/src/types/common/StateTabProps.ts
+++ b/src/types/common/StateTabProps.ts
@@ -1,0 +1,4 @@
+export interface StateTabProps {
+    tab1: string;
+    tab2: string;
+}


### PR DESCRIPTION
## 변경 내용

- 페이지별 PageTitle(글 제목 또는 탭 이름) 컴포넌트 생성
- PageTitle 아래의 State 별 tab을 나타내는 StateTab 컴포넌트 생성

## 특이 사항

- 없음.

## 체크리스트

-   [x] PR 날리기 전에 develop branch pull 받으셨나요?
-   [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
-   [x] 주석 Comment Anchors 컨벤션에 맞추어 다셨나요?

closes #28 
