### PR TITLE
#30 [style] 생성된 댓글 컴포넌트 UI 구현

### DIFF
--- a/src/components/Debate/Comment.tsx
+++ b/src/components/Debate/Comment.tsx
@@ -1,0 +1,61 @@
+import { DebateCommentProps } from '@/types/Debate/DebateCommentProps';
+import { Avatar, Box, Text, Badge } from '@chakra-ui/react';
+import React from 'react';
+import { AiOutlineEdit } from 'react-icons/ai';
+import { HiOutlineTrash } from 'react-icons/hi';
+
+const Comment: React.FC<DebateCommentProps> = ({
+    userImg,
+    userName,
+    commentContent,
+    isWriter,
+    time,
+}) => {
+    return (
+        <Box className="flex w-full p-4 rounded-md  bg-gray-100 mx-20 my-4">
+            {/*  SECTION - 유저 정보 부분 */}
+            <Box className="flex flex-col justify-center items-center justify-items-center align-middle w-24 mr-4">
+                <Avatar
+                    bg="teal.500"
+                    className="w-12 bg-gray-200 overflow-hidden rounded-full"
+                    src={userImg}
+                />
+                <Text>{userName}</Text>
+            </Box>
+
+            {/* SECTION - 나머지 컨텐츠 부분  */}
+            <Box className="flex-col w-full">
+                {/* SECTION - 가장 위 수정/삭제 아이콘 영역 */}
+                <Box className="flex justify-end text-gray-600 ">
+                    <HiOutlineTrash
+                        size="1.5rem"
+                        className="mr-1 hover:cursor-pointer"
+                    />
+                    <AiOutlineEdit
+                        size="1.5rem "
+                        className="hover:cursor-pointer"
+                    />
+                </Box>
+                {/* SECTION - 댓글 영역 */}
+                <Box>
+                    <Text>{commentContent}</Text>
+                </Box>
+                {/* SECTION - 배지 및 작성 시간 영역 */}
+                <Box className="flex justify-end items-baseline">
+                    {isWriter ? (
+                        <Badge
+                            variant="subtle"
+                            colorScheme="green"
+                            className="mr-2 h-full px-1 rounded-md text-sm bg-blue-200"
+                        >
+                            작성자
+                        </Badge>
+                    ) : null}
+                    <Text className="text-gray-600 ">{time}</Text>
+                </Box>
+            </Box>
+        </Box>
+    );
+};
+
+export default Comment;

--- a/src/components/Debate/Comment.tsx
+++ b/src/components/Debate/Comment.tsx
@@ -1,8 +1,15 @@
-import { DebateCommentProps } from '@/types/Debate/DebateCommentProps';
 import { Avatar, Box, Text, Badge } from '@chakra-ui/react';
 import React from 'react';
 import { AiOutlineEdit } from 'react-icons/ai';
 import { HiOutlineTrash } from 'react-icons/hi';
+
+interface DebateCommentProps {
+    userImg: string;
+    userName: string;
+    commentContent: string;
+    isWriter: boolean;
+    time: string;
+}
 
 const Comment: React.FC<DebateCommentProps> = ({
     userImg,

--- a/src/types/Debate/DebateCommentProps.ts
+++ b/src/types/Debate/DebateCommentProps.ts
@@ -1,7 +1,0 @@
-export interface DebateCommentProps {
-    userImg: string;
-    userName: string;
-    commentContent: string;
-    isWriter: boolean;
-    time: string;
-}

--- a/src/types/Debate/DebateCommentProps.ts
+++ b/src/types/Debate/DebateCommentProps.ts
@@ -1,0 +1,7 @@
+export interface DebateCommentProps {
+    userImg: string;
+    userName: string;
+    commentContent: string;
+    isWriter: boolean;
+    time: string;
+}


### PR DESCRIPTION
## 변경 내용

- 토론 페이지 내 생성된 댓글 컴포넌트 UI 구현
- 토론 댓글 타입 정의(임시)

## 특이 사항

- 토론 댓글 box 내의 flex 구성에 대해 상세히 주석 달아 두었음.

## 체크리스트

-   [x] PR 날리기 전에 develop branch pull 받으셨나요?
-   [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
-   [x] 주석 Comment Anchors 컨벤션에 맞추어 다셨나요?

closes #30 
