### PR TITLE
#34 [style] 투표,토론 페이지 목록 UI 구현

### DIFF
--- a/src/app/[starId]/done/page.tsx
+++ b/src/app/[starId]/done/page.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const Page = () => {
-    return <div>P</div>;
-};
-
-export default Page;

--- a/src/app/[starId]/page.tsx
+++ b/src/app/[starId]/page.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const page = () => {
-    return <div>page</div>;
-};
-
-export default page;

--- a/src/app/debateList/DebateListCard.tsx
+++ b/src/app/debateList/DebateListCard.tsx
@@ -1,0 +1,41 @@
+import { Box, Card, Heading, Text } from '@chakra-ui/react';
+import React from 'react';
+import { ListCardProps } from '@/types/star/ListCardProps';
+import { AiOutlineComment } from 'react-icons/ai';
+
+const DebateListCard: React.FC<ListCardProps<{ commentNum: number }>> = ({
+    originalTitle,
+    title,
+    username,
+    time,
+    option,
+}) => {
+    return (
+        <Card
+            className="flex border-2 w-full rounded-md my-2 p-4 justify-between"
+            direction={{ base: 'column', sm: 'row' }}
+            variant="outline"
+        >
+            <Box>
+                <Text className="text-md text-gray-400">{originalTitle}</Text>
+                <Heading className="text-lg font-semibold mb-1">
+                    {title}
+                </Heading>
+                <Box className="flex items-center mb-1">
+                    <Text className="mr-3 text-sm">{username}</Text>
+                    <Text className="text-sm" color="gray">
+                        {time}
+                    </Text>
+                </Box>
+            </Box>
+            <Box className="justify-between">
+                <Box className="flex">
+                    <AiOutlineComment size="1.5rem" />
+                    <Text>{option.commentNum}</Text>
+                </Box>
+            </Box>
+        </Card>
+    );
+};
+
+export default DebateListCard;

--- a/src/app/debateList/DebateListCard.tsx
+++ b/src/app/debateList/DebateListCard.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { ListCardProps } from '@/types/star/ListCardProps';
 import { AiOutlineComment } from 'react-icons/ai';
 
+// FIXME - 추후에 ListCard 컴포넌트들 재사용성을 높인 구조로 고치기
 const DebateListCard: React.FC<ListCardProps<{ commentNum: number }>> = ({
     originalTitle,
     title,

--- a/src/app/debateList/page.tsx
+++ b/src/app/debateList/page.tsx
@@ -1,24 +1,38 @@
-import ListCard from '@/components/Common/ListCard';
+import PageTitle from '@/components/Common/PageTitle';
+import StateTab from '@/components/Common/StateTab';
+import DebateListCard from '@/app/debateList/DebateListCard';
 import Wrapper from '@/components/Common/Wrapper';
-import dummyDebateList from '@/constants/dummyData';
+import { dummyDebateList } from '@/constants/dummyData';
 import React from 'react';
+import { Pagination } from '@mui/material';
+import { Center } from '@chakra-ui/react';
 
 const page = () => {
     return (
         <Wrapper>
+            <PageTitle pageTitle="토론" />
+            <StateTab tab1="진행중" tab2="종료" />
             {dummyDebateList.map(item => {
                 return (
-                    <ListCard
+                    <DebateListCard
                         key={item.id}
+                        originalTitle={item.originalTitle}
                         title={item.title}
                         username={item.username}
                         time={item.time}
                         content={item.content}
-                        likeNum={item.likeNum}
-                        dislikeNum={item.dislikeNum}
+                        option={{ commentNum: item.commentNum }}
                     />
                 );
             })}
+            <Center>
+                <Pagination
+                    count={10}
+                    showFirstButton
+                    showLastButton
+                    className="my-10 mb-20"
+                />
+            </Center>
         </Wrapper>
     );
 };

--- a/src/app/stars/[starId]/vote/SpecificVoteListCard.tsx
+++ b/src/app/stars/[starId]/vote/SpecificVoteListCard.tsx
@@ -4,6 +4,7 @@ import { ListCardProps } from '@/types/star/ListCardProps';
 import { LikeDislikeProps } from '@/types/common/LikeDislikeProps';
 import LikeDislike from '../../../../components/Common/LikeDislike';
 
+// FIXME - 추후에 ListCard 컴포넌트들 재사용성을 높인 구조로 고치기
 const SpecificVoteListCard: React.FC<ListCardProps<LikeDislikeProps>> = ({
     title,
     username,

--- a/src/app/stars/[starId]/vote/SpecificVoteListCard.tsx
+++ b/src/app/stars/[starId]/vote/SpecificVoteListCard.tsx
@@ -1,15 +1,15 @@
 import { Box, Card, Heading, Text } from '@chakra-ui/react';
 import React from 'react';
-import { ListCardProps } from '@/types/ListCardProps';
-import LikeDislike from './LikeDislike';
+import { ListCardProps } from '@/types/star/ListCardProps';
+import { LikeDislikeProps } from '@/types/common/LikeDislikeProps';
+import LikeDislike from '../../../../components/Common/LikeDislike';
 
-const ListCard: React.FC<ListCardProps> = ({
+const SpecificVoteListCard: React.FC<ListCardProps<LikeDislikeProps>> = ({
     title,
     username,
     time,
     content,
-    likeNum,
-    dislikeNum,
+    option,
 }) => {
     return (
         <Card
@@ -30,10 +30,13 @@ const ListCard: React.FC<ListCardProps> = ({
                 <Text className="text-md">{content}</Text>
             </Box>
             <Box className="justify-between">
-                <LikeDislike likeNum={likeNum} dislikeNum={dislikeNum} />
+                <LikeDislike
+                    likeNum={option.likeNum}
+                    dislikeNum={option.dislikeNum}
+                />
             </Box>
         </Card>
     );
 };
 
-export default ListCard;
+export default SpecificVoteListCard;

--- a/src/app/stars/[starId]/vote/page.tsx
+++ b/src/app/stars/[starId]/vote/page.tsx
@@ -5,8 +5,8 @@ import { useParams } from 'next/navigation';
 import Wrapper from '@/components/Common/Wrapper';
 import PageTitle from '@/components/Common/PageTitle';
 import StateTab from '@/components/Common/StateTab';
-import dummyDebateList from '@/constants/dummyData';
-import ListCard from '@/components/Common/ListCard';
+import { dummyVoteList } from '@/constants/dummyData';
+import SpecificVoteListCard from '@/app/stars/[starId]/vote/SpecificVoteListCard';
 import Pagination from '@mui/material/Pagination';
 import { Center } from '@chakra-ui/react';
 
@@ -19,16 +19,18 @@ const Page: React.FC = () => {
             <PageTitle pageTitle="마리모" />
             <StateTab tab1="요청중" tab2="완료" />
 
-            {dummyDebateList.map(item => {
+            {dummyVoteList.map(item => {
                 return (
-                    <ListCard
+                    <SpecificVoteListCard
                         key={id}
                         title={item.title}
                         username={item.username}
                         time={item.time}
                         content={item.content}
-                        likeNum={item.likeNum}
-                        dislikeNum={item.dislikeNum}
+                        option={{
+                            likeNum: item.likeNum,
+                            dislikeNum: item.dislikeNum,
+                        }}
                     />
                 );
             })}

--- a/src/app/voteList/VoteListCard.tsx
+++ b/src/app/voteList/VoteListCard.tsx
@@ -4,6 +4,7 @@ import { ListCardProps } from '@/types/star/ListCardProps';
 import { LikeDislikeProps } from '@/types/common/LikeDislikeProps';
 import LikeDislike from '../../components/Common/LikeDislike';
 
+// FIXME - 추후에 ListCard 컴포넌트들 재사용성을 높인 구조로 고치기
 const VoteListCard: React.FC<ListCardProps<LikeDislikeProps>> = ({
     originalTitle,
     title,

--- a/src/app/voteList/VoteListCard.tsx
+++ b/src/app/voteList/VoteListCard.tsx
@@ -1,0 +1,42 @@
+import { Box, Card, Heading, Text } from '@chakra-ui/react';
+import React from 'react';
+import { ListCardProps } from '@/types/star/ListCardProps';
+import { LikeDislikeProps } from '@/types/common/LikeDislikeProps';
+import LikeDislike from '../../components/Common/LikeDislike';
+
+const VoteListCard: React.FC<ListCardProps<LikeDislikeProps>> = ({
+    originalTitle,
+    title,
+    username,
+    time,
+    option,
+}) => {
+    return (
+        <Card
+            className="flex border-2 w-full rounded-md my-2 p-4 justify-between"
+            direction={{ base: 'column', sm: 'row' }}
+            variant="outline"
+        >
+            <Box>
+                <Text className="text-md text-gray-400">{originalTitle}</Text>
+                <Heading className="text-lg font-semibold mb-1">
+                    {title}
+                </Heading>
+                <Box className="flex items-center mb-1">
+                    <Text className="mr-3 text-sm">{username}</Text>
+                    <Text className="text-sm" color="gray">
+                        {time}
+                    </Text>
+                </Box>
+            </Box>
+            <Box className="justify-between">
+                <LikeDislike
+                    likeNum={option.likeNum}
+                    dislikeNum={option.dislikeNum}
+                />
+            </Box>
+        </Card>
+    );
+};
+
+export default VoteListCard;

--- a/src/app/voteList/page.tsx
+++ b/src/app/voteList/page.tsx
@@ -1,7 +1,56 @@
+import PageTitle from '@/components/Common/PageTitle';
+import StateTab from '@/components/Common/StateTab';
+import VoteListCard from '@/app/voteList/VoteListCard';
+import Wrapper from '@/components/Common/Wrapper';
+import { dummyVoteList } from '@/constants/dummyData';
+import { Box, Center, Select } from '@chakra-ui/react';
+import { Pagination } from '@mui/material';
 import React from 'react';
 
 const page = () => {
-    return <div>page</div>;
+    return (
+        <Wrapper>
+            <PageTitle pageTitle="투표" />
+            <Box className="flex justify-between w-full items-center">
+                <StateTab tab1="진행중" tab2="완료" />
+                <Box>
+                    <Select
+                        variant="outline"
+                        size="lg"
+                        className="bg-gray-100 rounded-md p-1"
+                    >
+                        <option value="전체">전체</option>
+                        <option value="반영완료">반영완료</option>
+                        <option value="진행중인 토론">진행중인 토론</option>
+                        <option value="종료된 토론">종료된 토론</option>
+                    </Select>
+                </Box>
+            </Box>
+            {dummyVoteList.map(item => {
+                return (
+                    <VoteListCard
+                        key={item.id}
+                        originalTitle={item.originalTitle}
+                        title={item.title}
+                        username={item.username}
+                        time={item.time}
+                        option={{
+                            likeNum: item.likeNum,
+                            dislikeNum: item.dislikeNum,
+                        }}
+                    />
+                );
+            })}
+            <Center>
+                <Pagination
+                    count={10}
+                    showFirstButton
+                    showLastButton
+                    className="my-10 mb-20"
+                />
+            </Center>
+        </Wrapper>
+    );
 };
 
 export default page;

--- a/src/components/Common/PageTitle.tsx
+++ b/src/components/Common/PageTitle.tsx
@@ -1,7 +1,7 @@
 import { Heading } from '@chakra-ui/react';
 import React from 'react';
 
-const PageTitle = (pageTitle: string) => {
+const PageTitle: React.FC<{ pageTitle: string }> = ({ pageTitle }) => {
     return (
         <Heading fontWeight={600} className="mb-4 text-3xl">
             {pageTitle}

--- a/src/constants/dummyData.ts
+++ b/src/constants/dummyData.ts
@@ -1,5 +1,48 @@
-const dummyDebateList = [
+export const dummyVoteList = [
     {
+        id: 1,
+        originalTitle: '날씨',
+        title: '마리모는 식물이 아니라 동물입니다',
+        username: '독수리타법 7남매',
+        time: '2024. 01. 10. 11:38',
+        content:
+            '마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.',
+        likeNum: 3,
+        dislikeNum: 1,
+    },
+    {
+        id: 2,
+        originalTitle: '날씨',
+        title: '오늘의 날씨는 궁금하지가 않습니다',
+        username: '여행갈고양',
+        time: '2024. 01. 10. 11:22',
+        content: '여행갈 때에는 오늘의 날씨가 중요하긴 합니다. 그러나',
+        likeNum: 22,
+        dislikeNum: 3,
+    },
+    {
+        id: 1,
+        originalTitle: '날씨',
+        title: '마리모는 식물이 아니라 동물입니다',
+        username: '독수리타법 7남매',
+        time: '2024. 01. 10. 11:38',
+        content:
+            '마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.',
+        likeNum: 3,
+        dislikeNum: 1,
+    },
+    {
+        id: 2,
+        originalTitle: '날씨',
+        title: '오늘의 날씨는 궁금하지가 않습니다',
+        username: '여행갈고양',
+        time: '2024. 01. 10. 11:22',
+        content: '여행갈 때에는 오늘의 날씨가 중요하긴 합니다. 그러나',
+        likeNum: 22,
+        dislikeNum: 3,
+    },
+    {
+        originalTitle: '날씨',
         id: 1,
         title: '마리모는 식물이 아니라 동물입니다',
         username: '독수리타법 7남매',
@@ -11,6 +54,7 @@ const dummyDebateList = [
     },
     {
         id: 2,
+        originalTitle: '날씨',
         title: '오늘의 날씨는 궁금하지가 않습니다',
         username: '여행갈고양',
         time: '2024. 01. 10. 11:22',
@@ -20,6 +64,7 @@ const dummyDebateList = [
     },
     {
         id: 1,
+        originalTitle: '날씨',
         title: '마리모는 식물이 아니라 동물입니다',
         username: '독수리타법 7남매',
         time: '2024. 01. 10. 11:38',
@@ -30,6 +75,7 @@ const dummyDebateList = [
     },
     {
         id: 2,
+        originalTitle: '날씨',
         title: '오늘의 날씨는 궁금하지가 않습니다',
         username: '여행갈고양',
         time: '2024. 01. 10. 11:22',
@@ -39,6 +85,7 @@ const dummyDebateList = [
     },
     {
         id: 1,
+        originalTitle: '날씨',
         title: '마리모는 식물이 아니라 동물입니다',
         username: '독수리타법 7남매',
         time: '2024. 01. 10. 11:38',
@@ -48,6 +95,7 @@ const dummyDebateList = [
         dislikeNum: 1,
     },
     {
+        originalTitle: '날씨',
         id: 2,
         title: '오늘의 날씨는 궁금하지가 않습니다',
         username: '여행갈고양',
@@ -55,44 +103,105 @@ const dummyDebateList = [
         content: '여행갈 때에는 오늘의 날씨가 중요하긴 합니다. 그러나',
         likeNum: 22,
         dislikeNum: 3,
+    },
+];
+
+export const dummyDebateList = [
+    {
+        id: 1,
+        originalTitle: '날씨',
+        title: '마리모는 식물이 아니라 동물입니다',
+        username: '독수리타법 7남매',
+        time: '2024. 01. 10. 11:38',
+        content:
+            '마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.',
+        commentNum: 4,
+    },
+    {
+        id: 2,
+        originalTitle: '날씨',
+        title: '오늘의 날씨는 궁금하지가 않습니다',
+        username: '여행갈고양',
+        time: '2024. 01. 10. 11:22',
+        content: '여행갈 때에는 오늘의 날씨가 중요하긴 합니다. 그러나',
+        commentNum: 4,
     },
     {
         id: 1,
+        originalTitle: '날씨',
         title: '마리모는 식물이 아니라 동물입니다',
         username: '독수리타법 7남매',
         time: '2024. 01. 10. 11:38',
         content:
             '마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.',
-        likeNum: 3,
-        dislikeNum: 1,
+        commentNum: 4,
     },
     {
         id: 2,
+        originalTitle: '날씨',
         title: '오늘의 날씨는 궁금하지가 않습니다',
         username: '여행갈고양',
         time: '2024. 01. 10. 11:22',
         content: '여행갈 때에는 오늘의 날씨가 중요하긴 합니다. 그러나',
-        likeNum: 22,
-        dislikeNum: 3,
+        commentNum: 4,
     },
     {
         id: 1,
+        originalTitle: '날씨',
         title: '마리모는 식물이 아니라 동물입니다',
         username: '독수리타법 7남매',
         time: '2024. 01. 10. 11:38',
         content:
             '마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.',
-        likeNum: 3,
-        dislikeNum: 1,
+        commentNum: 4,
     },
     {
         id: 2,
+        originalTitle: '날씨',
         title: '오늘의 날씨는 궁금하지가 않습니다',
         username: '여행갈고양',
         time: '2024. 01. 10. 11:22',
         content: '여행갈 때에는 오늘의 날씨가 중요하긴 합니다. 그러나',
         likeNum: 22,
-        dislikeNum: 3,
+        commentNum: 3,
+    },
+    {
+        id: 1,
+        originalTitle: '날씨',
+        title: '마리모는 식물이 아니라 동물입니다',
+        username: '독수리타법 7남매',
+        time: '2024. 01. 10. 11:38',
+        content:
+            '마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.',
+        commentNum: 4,
+    },
+    {
+        id: 2,
+        originalTitle: '날씨',
+        title: '오늘의 날씨는 궁금하지가 않습니다',
+        username: '여행갈고양',
+        time: '2024. 01. 10. 11:22',
+        content: '여행갈 때에는 오늘의 날씨가 중요하긴 합니다. 그러나',
+        commentNum: 4,
+    },
+    {
+        id: 1,
+        originalTitle: '날씨',
+        title: '마리모는 식물이 아니라 동물입니다',
+        username: '독수리타법 7남매',
+        time: '2024. 01. 10. 11:38',
+        content:
+            '마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.',
+        commentNum: 4,
+    },
+    {
+        id: 2,
+        originalTitle: '날씨',
+        title: '오늘의 날씨는 궁금하지가 않습니다',
+        username: '여행갈고양',
+        time: '2024. 01. 10. 11:22',
+        content: '여행갈 때에는 오늘의 날씨가 중요하긴 합니다. 그러나',
+        commentNum: 4,
     },
 ];
 

--- a/src/types/ListCardProps.ts
+++ b/src/types/ListCardProps.ts
@@ -1,8 +1,0 @@
-export interface ListCardProps {
-    title: string;
-    username: string;
-    time: string;
-    content: string;
-    likeNum: number;
-    dislikeNum: number;
-}

--- a/src/types/star/ListCardProps.ts
+++ b/src/types/star/ListCardProps.ts
@@ -1,0 +1,8 @@
+export interface ListCardProps<T> {
+    originalTitle?: string;
+    title: string;
+    username: string;
+    time: string;
+    content?: string;
+    option: T;
+}


### PR DESCRIPTION
## 변경 내용

- ListCardProps 타입 변경(좋아요/싫어요, 댓글 수를 option으로 설정)
- 특정 글, 투표, 토론의 렌더링 데이터가 달라서 각각의 Card 컴포넌트 정의(임시)
- 특정 글, 투표, 토론 전체 UI 설정
- PageTitle 타입 오류 해결

## 특이 사항

- 특정 글, 투표, 토론 각각의 Card 컴포넌트를 추후에 리팩토링을 통해 재사용성을 높이는 구조로 보완 필요
- 전체 구조를 위해 다른 수정사항들을 수정하다보니 파일 변화가 많아졌습니다.

## 체크리스트

-   [x] PR 날리기 전에 develop branch pull 받으셨나요?
-   [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
-   [x] 주석 Comment Anchors 컨벤션에 맞추어 다셨나요?

closes #34 
