### PR TITLE
[#66] style: 노드 hover시 flow 애니메이션, 같은 그룹 강조 효과 지정

### DIFF
--- a/src/app/(home)/components/GalaxyGraph.tsx
+++ b/src/app/(home)/components/GalaxyGraph.tsx
@@ -110,6 +110,37 @@ const ForceGraph = ({ nodes, links, searchResults }: GraphProps) => {
           .attr('stop-color', d3.color(color)!.darker(1).toString());
       });
 
+      const changeLinkColor = (link: any, color: string) => {
+        link.style('stroke', color);
+      };
+
+      // NOTE 호버 이벤트 핸들러
+      const handleMouseOver = (event: MouseEvent, hoveredNode: GraphNode) => {
+        node.style('opacity', 0.2);
+        node
+          .filter((node: GraphNode) => {return node.group === hoveredNode.group})
+          .style('opacity', 1);
+        link.attr('stroke-opacity', 0.5);
+
+        d3.select(event.target as SVGElement).style('cursor', 'pointer');
+
+        const relatedLinks = link.filter(
+          (d: GraphLink) =>
+            {return (d.source as GraphNode).group === hoveredNode.group &&
+            (d.target as GraphNode).group === hoveredNode.group},
+        );
+
+        changeLinkColor(relatedLinks, '#5c5cd6');
+        relatedLinks.classed(styles.flow, true);
+      };
+
+      const handleMouseOut = () => {
+        node.style('opacity', 1);
+        link.classed(styles.pulse, false);
+        changeLinkColor(link, '#999');
+        link.classed(styles.flow, false);
+      };
+
       // NOTE 줌 핸들러 정의
       const zoomHandler = d3
         .zoom<SVGSVGElement, unknown>()
@@ -175,6 +206,8 @@ const ForceGraph = ({ nodes, links, searchResults }: GraphProps) => {
           return `url(#gradient-${starColors.indexOf(colorScale(d.group))})`;
         })
         .on('click', handleNodeClick)
+        .on('mouseover', handleMouseOver)
+        .on('mouseout', handleMouseOut)
         .call(drag);
 
       const nodeText = svg

--- a/src/styles/graph.module.css
+++ b/src/styles/graph.module.css
@@ -21,3 +21,14 @@
 .blinking-node {
   animation: blinking 4s ease-in infinite;
 }
+
+@keyframes flowAnimation {
+  to {
+    stroke-dashoffset: 100;
+  }
+}
+
+.flow {
+  stroke-dasharray: 15;
+  animation: flowAnimation 2s linear infinite;
+}


### PR DESCRIPTION
## 변경 내용

- 그래프 노드 hover 시 link flow 애니매이션 적용
- 그래프 노드 hover 시 같은 그룹만 색상 그대로, 다른 그룹은 모두 opacity 감소 효과 적용

## 특이 사항

- useRef를 활용해 추후에 코드 리팩토링 할 예정.

## 체크리스트

-   [x] PR 날리기 전에 develop branch pull 받으셨나요?
-   [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
-   [x] 주석 Comment Anchors 컨벤션에 맞추어 다셨나요?

closes #66 
