### PR TITLE
#127 [feat] 토론 목록 기능 구현(페이지네이션 제외)

### DIFF
--- a/src/app/debateList/components/DebateListCard.tsx
+++ b/src/app/debateList/components/DebateListCard.tsx
@@ -23,6 +23,7 @@ const DebateListCard: React.FC<ListCardProps<{ commentNum: number }>> = ({
       borderColor="black"
       colorScheme="blue"
       direction={{ base: 'column', sm: 'row' }}
+      bg="white"
       _hover={{
         bg: 'gray.50',
         cursor: 'pointer',

--- a/src/app/debateList/page.tsx
+++ b/src/app/debateList/page.tsx
@@ -7,37 +7,34 @@ import Wrapper from '@/components/Common/Wrapper';
 import { dummyDebateList } from '@/constants/dummyData';
 import React, { useState } from 'react';
 import { Pagination } from '@mui/material';
-import { Center, Select } from '@chakra-ui/react';
+import { Center } from '@chakra-ui/react';
 import Link from 'next/link';
+import ChakraSelect from '@/components/Common/ChakraSelect';
 
 const Page = () => {
   const [activeTab, setActiveTab] = useState<string>('진행중');
+  const [selectedOption, setSelectedOption] = useState<string>('최신순');
+  const options = [
+    { value: '최신순', label: '최신순' },
+    { value: '최근 댓글 순', label: '최근 댓글 순' },
+  ];
 
   // activeTab에 따라서 다른 axios 호출
+
+  // selectedOption 따라서 다른 axios 호출
+  console.log(selectedOption);
+
   return (
     <Wrapper>
       <PageTitle pageTitle="토론" />
-      <div className="flex justify-between w-full items-center my-0">
+      <div className="flex justify-between w-full items-center">
         <StateTab
           tab1="진행중"
           tab2="완료"
           activeTab={activeTab}
           setActiveTab={setActiveTab}
         />
-        <div className="flex my-0">
-          <Select
-            variant="filled"
-            size="sm"
-            rounded="md"
-            borderColor="gray.200"
-            borderWidth={1}
-            focusBorderColor="gray.400"
-            bg="white"
-          >
-            <option value="최신순">최신순</option>
-            <option value="최근댓글순">최근댓글순</option>
-          </Select>
-        </div>
+        <ChakraSelect options={options} setSelectedOption={setSelectedOption} />
       </div>
       {dummyDebateList.map(item => {
         return (

--- a/src/app/debateList/page.tsx
+++ b/src/app/debateList/page.tsx
@@ -4,26 +4,82 @@ import PageTitle from '@/components/Common/PageTitle';
 import StateTab from '@/components/Common/StateTab';
 import DebateListCard from '@/app/debateList/components/DebateListCard';
 import Wrapper from '@/components/Common/Wrapper';
-import { dummyDebateList } from '@/constants/dummyData';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Pagination } from '@mui/material';
 import { Center } from '@chakra-ui/react';
 import Link from 'next/link';
 import ChakraSelect from '@/components/Common/ChakraSelect';
+import axios from 'axios';
+
+interface Debate {
+  debateId: number;
+  createdAt: string;
+  endAt: string;
+  documentId: number;
+  documentTitle: string;
+  contributeId: number;
+  contributeTitle: string;
+  commentsCount: number;
+  contributor: {
+    memberId: number;
+    nickname: string;
+    profileImgUrl: string;
+  };
+}
+
+interface ApiResponse {
+  success: boolean;
+  message: string;
+  results: {
+    debates: Debate[];
+    totalPages: number;
+  };
+}
 
 const Page = () => {
   const [activeTab, setActiveTab] = useState<string>('진행중');
   const [selectedOption, setSelectedOption] = useState<string>('최신순');
+  const [debateLists, setDebateLists] = useState<Debate[]>([]);
+  // TODO 추후 추가 예정
+  // const [totalPages, setTotalPages] = useState<number>();
   const options = [
     { value: '최신순', label: '최신순' },
     { value: '최근 댓글 순', label: '최근 댓글 순' },
   ];
 
-  // activeTab에 따라서 다른 axios 호출
+  // NOTE activeTab에 따라서 다른 axios 호출
+  const getDebateLists = async () => {
+    try {
+      const response = await axios.get<ApiResponse>(
+        `${process.env.NEXT_PUBLIC_SERVER_URL}/api/debates`,
+        {
+          params: {
+            status: activeTab === '진행중' ? 'OPEN' : 'CLOSED',
+            // sort: selectedOption === '최신순' ? 'latest' : 'recentComment',
+          },
+        },
+      );
 
-  // selectedOption 따라서 다른 axios 호출
-  console.log(selectedOption);
+      if (response.data.success) {
+        console.log('데이터 로딩 성공:', response.data.results);
+        setDebateLists(response.data.results.debates);
+        // TODO 추후 추가 예정
+        // setTotalPages(response.data.results.totalPages);
+      } else {
+        console.log('서버로부터 실패 메시지:', response.data.message);
+      }
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        console.log('Axios 에러 발생:', error.message);
+      } else {
+        console.log('알 수 없는 에러 발생:', error);
+      }
+    }
+  };
 
+  useEffect(() => {
+    getDebateLists();
+  }, [activeTab, selectedOption]);
   return (
     <Wrapper>
       <PageTitle pageTitle="토론" />
@@ -36,16 +92,15 @@ const Page = () => {
         />
         <ChakraSelect options={options} setSelectedOption={setSelectedOption} />
       </div>
-      {dummyDebateList.map(item => {
+      {debateLists.map(item => {
         return (
-          <Link href={`/debateList/${item.id}`} key={item.id}>
+          <Link href={`/debateList/${item.debateId}`} key={item.debateId}>
             <DebateListCard
-              originalTitle={item.originalTitle}
-              title={item.title}
-              username={item.username}
-              time={item.time}
-              content={item.content}
-              option={{ commentNum: item.commentNum }}
+              originalTitle={item.documentTitle}
+              title={item.documentTitle}
+              username={item.contributor.nickname}
+              time={`${item.createdAt}~${item.endAt}`}
+              option={{ commentNum: item.commentsCount }}
             />
           </Link>
         );

--- a/src/app/debateList/page.tsx
+++ b/src/app/debateList/page.tsx
@@ -6,6 +6,7 @@ import { dummyDebateList } from '@/constants/dummyData';
 import React from 'react';
 import { Pagination } from '@mui/material';
 import { Center, Select } from '@chakra-ui/react';
+import Link from 'next/link';
 
 const Page = () => {
   return (
@@ -30,15 +31,16 @@ const Page = () => {
       </div>
       {dummyDebateList.map(item => {
         return (
-          <DebateListCard
-            key={item.id}
-            originalTitle={item.originalTitle}
-            title={item.title}
-            username={item.username}
-            time={item.time}
-            content={item.content}
-            option={{ commentNum: item.commentNum }}
-          />
+          <Link href={`/debateList/${item.id}`} key={item.id}>
+            <DebateListCard
+              originalTitle={item.originalTitle}
+              title={item.title}
+              username={item.username}
+              time={item.time}
+              content={item.content}
+              option={{ commentNum: item.commentNum }}
+            />
+          </Link>
         );
       })}
       <Center>

--- a/src/app/debateList/page.tsx
+++ b/src/app/debateList/page.tsx
@@ -14,7 +14,15 @@ const Page = () => {
       <div className="flex justify-between w-full items-center my-0">
         <StateTab tab1="진행중" tab2="완료" />
         <div className="flex my-0">
-          <Select variant="outline" size="sm" rounded="md">
+          <Select
+            variant="filled"
+            size="sm"
+            rounded="md"
+            borderColor="gray.200"
+            borderWidth={1}
+            focusBorderColor="gray.400"
+            bg="white"
+          >
             <option value="최신순">최신순</option>
             <option value="최근댓글순">최근댓글순</option>
           </Select>

--- a/src/app/debateList/page.tsx
+++ b/src/app/debateList/page.tsx
@@ -1,19 +1,29 @@
+'use client';
+
 import PageTitle from '@/components/Common/PageTitle';
 import StateTab from '@/components/Common/StateTab';
 import DebateListCard from '@/app/debateList/components/DebateListCard';
 import Wrapper from '@/components/Common/Wrapper';
 import { dummyDebateList } from '@/constants/dummyData';
-import React from 'react';
+import React, { useState } from 'react';
 import { Pagination } from '@mui/material';
 import { Center, Select } from '@chakra-ui/react';
 import Link from 'next/link';
 
 const Page = () => {
+  const [activeTab, setActiveTab] = useState<string>('진행중');
+
+  // activeTab에 따라서 다른 axios 호출
   return (
     <Wrapper>
       <PageTitle pageTitle="토론" />
       <div className="flex justify-between w-full items-center my-0">
-        <StateTab tab1="진행중" tab2="완료" />
+        <StateTab
+          tab1="진행중"
+          tab2="완료"
+          activeTab={activeTab}
+          setActiveTab={setActiveTab}
+        />
         <div className="flex my-0">
           <Select
             variant="filled"

--- a/src/app/stars/[starId]/voteList/page.tsx
+++ b/src/app/stars/[starId]/voteList/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import { useParams } from 'next/navigation';
 import Wrapper from '@/components/Common/Wrapper';
 import PageTitle from '@/components/Common/PageTitle';
@@ -13,11 +13,17 @@ import { Center } from '@chakra-ui/react';
 const Page: React.FC = () => {
   const params = useParams<{ starId: string }>();
   const id = params.starId;
+  const [activeTab, setActiveTab] = useState<string>('요청중');
 
   return (
     <Wrapper>
       <PageTitle pageTitle="마리모" />
-      <StateTab tab1="요청중" tab2="완료" />
+      <StateTab
+        tab1="요청중"
+        tab2="완료"
+        activeTab={activeTab}
+        setActiveTab={setActiveTab}
+      />
 
       {dummyVoteList.map(item => {
         return (

--- a/src/app/voteList/page.tsx
+++ b/src/app/voteList/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import PageTitle from '@/components/Common/PageTitle';
 import StateTab from '@/components/Common/StateTab';
 import VoteListCard from '@/app/voteList/components/VoteListCard';
@@ -5,14 +7,21 @@ import Wrapper from '@/components/Common/Wrapper';
 import { dummyVoteList } from '@/constants/dummyData';
 import { Center, Select } from '@chakra-ui/react';
 import { Pagination } from '@mui/material';
-import React from 'react';
+import React, { useState } from 'react';
 
 const Page = () => {
+  const [activeTab, setActiveTab] = useState<string>('진행중');
+
   return (
     <Wrapper>
       <PageTitle pageTitle="투표" />
       <div className="flex justify-between w-full items-center my-0">
-        <StateTab tab1="진행중" tab2="완료" />
+        <StateTab
+          tab1="진행중"
+          tab2="완료"
+          activeTab={activeTab}
+          setActiveTab={setActiveTab}
+        />
         <div className="flex my-0">
           <Select variant="outline" size="sm" rounded="md">
             <option value="전체">전체</option>

--- a/src/components/Common/ChakraSelect.tsx
+++ b/src/components/Common/ChakraSelect.tsx
@@ -1,0 +1,44 @@
+import { Select } from '@chakra-ui/react';
+import React, { ChangeEvent } from 'react';
+
+interface Option {
+  value: string;
+  label: string;
+}
+
+interface ChakraSelectProps {
+  options: Option[];
+  setSelectedOption: (selected: string) => void;
+}
+
+const ChakraSelect: React.FC<ChakraSelectProps> = ({
+  options,
+  setSelectedOption,
+}) => {
+  const handleSelectedOption = (e: ChangeEvent<HTMLSelectElement>) => {
+    setSelectedOption(e.currentTarget.value);
+    console.log(e.currentTarget.value);
+  };
+  return (
+    <div className="flex my-0">
+      <Select
+        variant="filled"
+        size="sm"
+        rounded="md"
+        borderColor="gray.200"
+        borderWidth={1}
+        focusBorderColor="gray.400"
+        bg="white"
+        onChange={handleSelectedOption}
+      >
+        {options.map(option => {return (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        )})}
+      </Select>
+    </div>
+  );
+};
+
+export default ChakraSelect;

--- a/src/components/Common/StateTab.tsx
+++ b/src/components/Common/StateTab.tsx
@@ -1,19 +1,17 @@
 'use client';
 
 import { Button } from '@chakra-ui/react';
-import { useState } from 'react';
 
 const StateTab: React.FC<{
   tab1: string;
   tab2: string;
-}> = ({ tab1, tab2 }) => {
-  const [active, setActive] = useState<string>(tab1);
-
+  activeTab: string;
+  setActiveTab: (tab: string) => void;
+}> = ({ tab1, tab2, activeTab, setActiveTab }) => {
   const handleKeyDown = (e: React.KeyboardEvent, tab: string) => {
-    // 'Enter' 또는 'Space' 키가 눌렸는지 확인
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
-      setActive(tab);
+      setActiveTab(tab);
     }
   };
 
@@ -23,12 +21,12 @@ const StateTab: React.FC<{
         variant="ghost"
         fontSize="lg"
         fontWeight="semibold"
-        color={active === tab1 ? 'black' : 'gray.300'}
+        color={activeTab === tab1 ? 'black' : 'gray.300'}
         mr={4}
         _hover={{ cursor: 'pointer', bg: 'none' }}
         padding={0}
         onClick={() => {
-          return setActive(tab1);
+          return setActiveTab(tab1);
         }}
         onKeyDown={e => {
           return handleKeyDown(e, tab1);
@@ -43,12 +41,12 @@ const StateTab: React.FC<{
         variant="ghost"
         fontSize="lg"
         fontWeight="semibold"
-        color={active === tab2 ? 'black' : 'gray.300'}
+        color={activeTab === tab2 ? 'black' : 'gray.300'}
         mr={4}
         _hover={{ cursor: 'pointer', bg: 'none' }}
         padding={0}
         onClick={() => {
-          return setActive(tab2);
+          return setActiveTab(tab2);
         }}
         onKeyDown={e => {
           return handleKeyDown(e, tab2);

--- a/src/components/Common/StateTab.tsx
+++ b/src/components/Common/StateTab.tsx
@@ -21,34 +21,40 @@ const StateTab: React.FC<{
     <div className="flex my-6">
       <Button
         variant="ghost"
-        className={
-          active === tab1
-            ? 'text-lg font-semibold mr-4 hover:cursor-pointer p-0'
-            : 'text-lg text-gray-300 font-semibold mr-4 hover:cursor-pointer p-0'
-        }
-        _hover={{ bg: 'none' }}
-        onClick={() => {return setActive(tab1)}}
-        onKeyDown={e => {return handleKeyDown(e, tab1)}}
+        fontSize="lg"
+        fontWeight="semibold"
+        color={active === tab1 ? 'black' : 'gray.300'}
+        mr={4}
+        _hover={{ cursor: 'pointer', bg: 'none' }}
+        padding={0}
+        onClick={() => {
+          return setActive(tab1);
+        }}
+        onKeyDown={e => {
+          return handleKeyDown(e, tab1);
+        }}
         role="button"
         tabIndex={0}
-        size="sm"
       >
         {tab1}
       </Button>
 
       <Button
         variant="ghost"
-        className={
-          active === tab2
-            ? 'text-lg font-semibold mr-4 hover:cursor-pointer p-0'
-            : 'text-lg text-gray-300 font-semibold mr-4 hover:cursor-pointer p-0'
-        }
-        _hover={{ bg: 'none' }}
-        onClick={() => {return setActive(tab2)}}
-        onKeyDown={e => {return handleKeyDown(e, tab2)}}
+        fontSize="lg"
+        fontWeight="semibold"
+        color={active === tab2 ? 'black' : 'gray.300'}
+        mr={4}
+        _hover={{ cursor: 'pointer', bg: 'none' }}
+        padding={0}
+        onClick={() => {
+          return setActive(tab2);
+        }}
+        onKeyDown={e => {
+          return handleKeyDown(e, tab2);
+        }}
         role="button"
         tabIndex={0}
-        size="sm"
       >
         {tab2}
       </Button>


### PR DESCRIPTION
## 변경 내용

- 토론 UI 오류 수정
- 토론 카드 클릭 시 상세페이지로 라우팅 구현
- StateTab 공통 컴포넌트 수정
- select 공통 컴포넌트로 분리
- 토론 목록 탭에 따른 서버 api 호출 및 렌더링 구현

## 특이 사항

- 서버 미구현 사항(option에 따른 정렬) 추후 구현 필요
- 이슈 단위를 작게 가져가기 위해 pagenation 다른 이슈로 분리

## 체크리스트

-   [x] PR 날리기 전에 develop branch pull 받으셨나요?
-   [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
-   [x] 주석 Comment Anchors 컨벤션에 맞추어 다셨나요?

closes #127 
