### PR TITLE
#156 [style] 투표 상세페이지 UI 수정

### DIFF
--- a/src/app/vote-list/[voteId]/components/ReviseInformation.tsx
+++ b/src/app/vote-list/[voteId]/components/ReviseInformation.tsx
@@ -1,40 +1,104 @@
 import React from 'react';
 import LabelText from '@/components/Common/LabelText';
 
-// FIXME - 백엔드 api 확인 후 변경
+// TODO - type, heading, status는 열거형 or 유니온 타입으로 변경
+/*
+export const Type = {
+  update: 'UPDATE',
+  create: 'CREATE',
+  delete: 'DELETE',
+} as const;
+export const Heading = {
+  h1: 'H1',
+  h2: 'H2',
+  h3: 'H3',
+  h4: 'H4',
+  h5: 'H5',
+  h6: 'H6',
+} as const;
+export const Status = {
+  voting: 'VOTING',
+  merged: 'MERGED',
+  rejected: 'REJECTED',
+  debating: 'DEBATING',
+} as const;
+*/
+
 // NOTE - 수정요청 글의 정보 type
-interface ReviseDataProps {
-  documentTitle: string;
+interface AmendmentData {
+  amendmentId: number;
+  type: string;
+  targetSection: {
+    sectionId: number;
+    revision: number;
+    heading: string;
+    title: string;
+    content: string;
+  };
+  requestedSectionHeading: string;
+  requestedSectionTitle: string;
+  requestedSectionContent: string;
+  creatingOrder: number;
+}
+interface ReviseDataResponse {
+  contributeId: number;
   contributeTitle: string;
-  relatedDebateNum: string; // FIXME - 백엔드 필드명 확인 후 변경
-  parentTitle: string;
-  contributorNickname: string;
-  remainVoteTime: number; // FIXME - 백엔드 필드명 확인 후 변경
   contributeDescription: string;
+  contributeStatus: string;
+  documentId: number;
+  documentTitle: string;
+  parentDocumentId: number;
+  contributor: {
+    memberId: number;
+    nickname: string;
+    profileImgUrl: string;
+  };
+  amendments: AmendmentData[];
+  beforeDocumentTitle: string;
+  afterDocumentTitle: string;
+  beforeParentDocumentId: number;
+  beforeParentDocumentTitle: string;
+  afterParentDocumentId: number;
+  afterParentDocumentTitle: string;
+  endAt: string;
+  relatedDebateId: number;
 }
 
-const ReviseInformation = ({ reviseData }: { reviseData: ReviseDataProps }) => {
+const ReviseInformation = ({
+  reviseData,
+}: {
+  reviseData: ReviseDataResponse;
+}) => {
   return (
-    <div className="flex flex-col gap-6">
-      <LabelText label="글 제목" text={reviseData.documentTitle} />
-      <LabelText label="수정 요청안 제목" text={reviseData.contributeTitle} />
+    <div className="flex flex-col gap-8">
       <div className="grid grid-cols-2 gap-4">
+        <LabelText label="글 제목" text={reviseData.documentTitle || '제목'} />
         <LabelText
-          label="연관된 토론 번호"
-          text={`#${reviseData.relatedDebateNum}`}
+          label="상위 계층 태그"
+          text={`${reviseData.parentDocumentId}` || '상위 계층 태그'}
         />
-        <LabelText label="상위 계층 태그" text={reviseData.parentTitle} />
       </div>
       <div className="grid grid-cols-2 gap-4">
-        <LabelText label="수정 요청자" text={reviseData.contributorNickname} />
         <LabelText
-          label="남은 투표 시간"
-          text={`${reviseData.remainVoteTime}분`}
+          label="수정 요청안 제목"
+          text={reviseData.contributeTitle || '수정요청안 제목'}
+        />
+        <LabelText label="남은 투표 시간" text="sss" />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <LabelText
+          label="수정 요청자"
+          text={reviseData.contributor?.nickname || '수정요청자'}
+        />
+        <LabelText
+          label="연관된 토론 번호"
+          text={`#${reviseData.relatedDebateId || '연관된 토론 번호'}`}
         />
       </div>
       <LabelText
         label="수정 요청 이유"
-        text={reviseData.contributeDescription}
+        text={reviseData.contributeDescription || '수정 요청 이유'}
       />
     </div>
   );

--- a/src/app/vote-list/[voteId]/page.tsx
+++ b/src/app/vote-list/[voteId]/page.tsx
@@ -3,6 +3,7 @@ import Wrapper from '@/components/Common/Wrapper';
 import { Card, Input } from '@chakra-ui/react';
 import React from 'react';
 import ReviseInformation from '@/app/vote-list/[voteId]/components/ReviseInformation';
+import PageTitleDescription from '@/components/Common/PageTitleDescription';
 import Vote from './components/Vote';
 
 // FIXME 백엔드 통신 이후 삭제
@@ -60,10 +61,10 @@ const Page = () => {
     <Wrapper>
       <div className="pt-5">
         {/* TODO 페이지 제목 - 공통컴포넌트로 분리 */}
-        <div className="flex flex-col gap-1 mb-16">
-          <h1 className="text-3xl font-bold">투표하기</h1>
-          <p className="text-sm">수정요청 반영 여부에 대해 투표하세요! </p>
-        </div>
+        <PageTitleDescription
+          title="투표하기"
+          description="수정요청 반영 여부에 대해 투표하세요!"
+        />
         <div className="flex flex-col gap-8">
           {/* SECTION 수정요청 글 정보 영역 */}
           <ReviseInformation reviseData={dummyReviseData} />

--- a/src/app/vote-list/[voteId]/page.tsx
+++ b/src/app/vote-list/[voteId]/page.tsx
@@ -1,36 +1,52 @@
 import BeforeAfter from '@/components/Common/BeforeAfter';
 import Wrapper from '@/components/Common/Wrapper';
-import { Card } from '@chakra-ui/react';
+import { Card, Input } from '@chakra-ui/react';
 import React from 'react';
 import ReviseInformation from '@/app/vote-list/[voteId]/components/ReviseInformation';
 import Vote from './components/Vote';
 
 // FIXME 백엔드 통신 이후 삭제
 const dummyReviseData = {
-  documentTitle: '마리모',
+  contributeId: 2,
   contributeTitle: '마리모에 대한 전반적인 수정 요청',
-  relatedDebateNum: '12345',
-  parentTitle: '식물',
-  contributorNickname: '독수리타법 7남매',
-  remainVoteTime: 120,
   contributeDescription:
-    '마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.',
-  contents: [
+    '마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.마리모는 동물입니다. 동물을 식물이라고 부르는 것은 마리모에게 실례입니다.',
+  contributeStatus: 'VOTING',
+  documentId: 1,
+  documentTitle: '마리모',
+  parentDocumentId: 456,
+  contributor: {
+    memberId: 101,
+    nickname: '독수리타법 7남매',
+    profileImgUrl: '',
+  },
+  amendments: [
     {
-      id: 1,
-      title: '마리모는 식물이 아닙니다.',
-      beforeContent:
-        '마리모(일본어: 毬藻; 라틴어: Aegagropila linnaei)는 공 모양의 집합체를 만드는 것으로 잘 알려져 있는 담수성 녹조류의 일종이다. 또한 아칸호의 마리모는 특히 아름다운 구상체를 만들며, 마리모는 일본의 천연기념물로 지정되어 있다./n그리고 마리모는 공 모양의 집합체를 형성하지만 그 구상체 하나가 곧 마리모 한 개체인 것이 아니고, 그 구상체를 구성하는 가는 섬유(사상체)가 마리모의 개체 단위이다. 많은 서식지에서 마리모는 구상체를 구성하지 않고 사상체의 형태로 산다. 겉보기에는 부드러울 것 같지만 실제로는 딱딱한 말(녹조)로, 만져보면 쿡쿡 찔리는 듯한 감촉이 있다.\n1897년 일본에서 삿포로 농학교(현 홋카이도 대학)의 카와카미 타키야가 아칸 호에서 발견한 형태를 더러 マリモ(毬藻), 즉 ‘둥근 마름풀’이라는 이름을 붙였다.',
-      afterContent: '마리모는 동물이다.',
-    },
-    {
-      id: 2,
-      title: '마리모는 귀엽습니다.',
-      beforeContent: '',
-      afterContent:
-        '마리모가 어항 위로 올라오는 행동은 광합성을 통해 생긴 기포에 의한 것이다. 요즘엔 다시 반려식물로 인기를 누리고 있다. 마트에 가면 볼 수 있는 반려식물중 하나이다. 또한 마리모는 기분이 좋으면 떠오르는데, 이때 소원을 빌면 이루어진다는 전설이 있다.',
+      amendmentId: 123,
+      type: 'UPDATE',
+      targetSection: {
+        // 수정 전
+        sectionId: 456,
+        revision: 8,
+        heading: 'H1',
+        title: '마리모는 식물이 아닙니다.',
+        content: '마리모는 동물이다.',
+      },
+      // 수정 후
+      requestedSectionHeading: 'H1',
+      requestedSectionTitle: '마리모는 식물입니다',
+      requestedSectionContent: '마리모는 식물입니다 절대 동물일 수가 없습니다',
+      creatingOrder: 1,
     },
   ],
+  beforeDocumentTitle: '가나다라마사아자차카타파하가나',
+  afterDocumentTitle: '가나다라마사아자차카타파하가나',
+  beforeParentDocumentId: 987,
+  beforeParentDocumentTitle: '녹조류',
+  afterParentDocumentId: 456,
+  afterParentDocumentTitle: '양서류',
+  endAt: '2024-05-15T09:32',
+  relatedDebateId: 45384,
 };
 
 const dummyVoteData = {
@@ -42,29 +58,107 @@ const dummyVoteData = {
 const Page = () => {
   return (
     <Wrapper>
-      <div className="px-32 pt-5 ">
-        {/* TODO 수정요청사항과 투표 영역 구분하기 - 고민하기 */}
-        <Card paddingY="2rem" paddingX="2rem">
-          <div className="flex flex-col gap-4">
-            {/* SECTION 수정요청 글 정보 영역 */}
-            <ReviseInformation reviseData={dummyReviseData} />
-
+      <div className="pt-5">
+        {/* TODO 페이지 제목 - 공통컴포넌트로 분리 */}
+        <div className="flex flex-col gap-1 mb-16">
+          <h1 className="text-3xl font-bold">투표하기</h1>
+          <p className="text-sm">수정요청 반영 여부에 대해 투표하세요! </p>
+        </div>
+        <div className="flex flex-col gap-8">
+          {/* SECTION 수정요청 글 정보 영역 */}
+          <ReviseInformation reviseData={dummyReviseData} />
+          <hr />
+          <div className="flex flex-col">
+            <h2 className="text-xl font-bold mb-4">수정 요청 사항</h2>
+            <div className="grid grid-cols-2 mb-10">
+              <p className="text-lg text-center text-gray-500">수정 전</p>
+              <p className="text-lg text-center text-gray-500">수정 후</p>
+            </div>
+            {/* SECTION 글 제목 */}
+            {dummyReviseData.beforeDocumentTitle ===
+              dummyReviseData.afterDocumentTitle || (
+              <div className="mb-6">
+                <h3 className="text font-bold">글 제목</h3>
+                <div className="grid grid-cols-2 mt-2 gap-4">
+                  <Input
+                    isDisabled
+                    value={dummyReviseData.beforeDocumentTitle}
+                    bg="white"
+                    textAlign="center"
+                    paddingY="1.5rem"
+                    sx={{
+                      _disabled: {
+                        color: 'black',
+                      },
+                    }}
+                  />
+                  <Input
+                    isDisabled
+                    value={dummyReviseData.afterDocumentTitle}
+                    bg="white"
+                    textAlign="center"
+                    paddingY="1.5rem"
+                    sx={{
+                      _disabled: {
+                        color: 'black',
+                      },
+                    }}
+                  />
+                </div>
+              </div>
+            )}
+            {dummyReviseData.beforeParentDocumentTitle ===
+              dummyReviseData.afterParentDocumentTitle || (
+              <div>
+                <h3 className="text font-bold">상위 계층 태그</h3>
+                <div className="grid grid-cols-2 mt-2 gap-4">
+                  <Input
+                    isDisabled
+                    value={dummyReviseData.beforeParentDocumentTitle}
+                    bg="white"
+                    textAlign="center"
+                    paddingY="1.5rem"
+                    sx={{
+                      _disabled: {
+                        color: 'black',
+                      },
+                    }}
+                  />
+                  <Input
+                    isDisabled
+                    value={dummyReviseData.afterParentDocumentTitle}
+                    bg="white"
+                    textAlign="center"
+                    paddingY="1.5rem"
+                    sx={{
+                      _disabled: {
+                        color: 'black',
+                      },
+                    }}
+                  />
+                </div>
+              </div>
+            )}
+            {/* SECTION 상위 계층 태그 */}
             {/* SECTION 수정요청 사항 내용 영역 */}
-            <div className="flex flex-col gap-16 mt-10">
-              {dummyReviseData.contents.map((content, index) => {
+            <div className="flex flex-col gap-16 mt-16">
+              {dummyReviseData.amendments.map((amendment, index) => {
                 return (
                   <BeforeAfter
-                    key={content.id}
+                    key={amendment.amendmentId}
                     index={index}
-                    title={content.title}
-                    before={content.beforeContent}
-                    after={content.afterContent}
+                    beforeHeading={amendment.targetSection.heading}
+                    afterHeading={amendment.requestedSectionHeading}
+                    beforeTitle={amendment.targetSection.title}
+                    afterTitle={amendment.requestedSectionTitle}
+                    beforeContent={amendment.targetSection.content}
+                    afterContent={amendment.requestedSectionContent}
                   />
                 );
               })}
             </div>
           </div>
-        </Card>
+        </div>
         {/* SECTION 투표 영역 */}
         <div className="mt-16">
           <Card padding="2rem">

--- a/src/components/Common/BeforeAfter.tsx
+++ b/src/components/Common/BeforeAfter.tsx
@@ -3,33 +3,35 @@ import React from 'react';
 
 const BeforeAfter = ({
   index,
-  title,
-  before,
-  after,
+  beforeHeading,
+  afterHeading,
+  beforeTitle,
+  afterTitle,
+  beforeContent,
+  afterContent,
 }: {
   index: number;
-  title: string;
-  before: string;
-  after: string;
+  beforeHeading: string;
+  afterHeading: string;
+  beforeTitle: string;
+  afterTitle: string;
+  beforeContent: string;
+  afterContent: string;
 }) => {
   return (
-    <div className="flex flex-col gap-5">
-      {/* SECTION 수정 요청 사항 제목 영역 */}
-      <h1 className="text-lg font-bold text-center">
-        수정 요청 사항 #{index + 1} : {title}
-      </h1>
-      {/* SECTION 수정 요청 사항 내용 영역 */}
+    <div className="flex flex-col gap-3">
+      <h1 className="text-lg font-bold">#{index + 1}</h1>
       <div className="grid grid-cols-2 gap-5">
-        {/* SECTION 수정 전 내용 영역 */}
         <div className="flex flex-col gap-1">
-          <p className="text-center font-bold">수정 전</p>
           <Textarea
             isDisabled
-            value={before}
+            value={`${beforeHeading} ${beforeTitle}${'\n'}${beforeContent}`}
             height="20rem"
             lineHeight="1.5rem"
             resize="none"
             padding={5}
+            fontSize="md"
+            backgroundColor="white"
             sx={{
               _disabled: {
                 color: 'black',
@@ -37,16 +39,16 @@ const BeforeAfter = ({
             }}
           />
         </div>
-        {/* SECTION 수정 후 내용 영역 */}
         <div className="flex flex-col gap-1">
-          <p className="text-center font-bold">수정 후</p>
           <Textarea
             isDisabled
-            value={after}
+            value={`${afterHeading} ${afterTitle}${'\n'}${afterContent}`}
             height="20rem"
             lineHeight="1.5rem"
             resize="none"
             padding={5}
+            fontSize="md"
+            backgroundColor="white"
             sx={{
               _disabled: {
                 color: 'black',

--- a/src/components/Common/LabelText.tsx
+++ b/src/components/Common/LabelText.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 const LabelText = ({ label, text }: { label: string; text: string }) => {
   return (
     <div className="flex">
-      <h3 className="font-bold text-base w-36">{label}</h3>
-      <p className="text-base">{text}</p>
+      <h3 className="font-bold text-md w-36">{label}</h3>
+      <p className="text-md flex-1">{text}</p>
     </div>
   );
 };

--- a/src/components/Common/PageTitleDescription.tsx
+++ b/src/components/Common/PageTitleDescription.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const PageTitleDescription = ({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) => {
+  return (
+    <div className="flex flex-col gap-1 mb-16">
+      <h1 className="text-3xl font-bold">{title}</h1>
+      <p className="text-sm">{description}</p>
+    </div>
+  );
+};
+
+export default PageTitleDescription;


### PR DESCRIPTION
## 변경 내용

- 투표 상세페이지 ui 수정
- 공통컴포넌트: 페이지 제목과 설명(figma에서 수정요청 페이지, 투표 상세페이지, 토론 상세페이지 등에서 사용)

## 특이 사항

- 더미데이터는 다음 이슈에서 삭제 후 api 연결할 계획입니다

## 체크리스트

-   [x] PR 날리기 전에 develop branch pull 받으셨나요?
-   [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
-   [x] 주석 Comment Anchors 컨벤션에 맞추어 다셨나요?

closes #156 
