### PR TITLE
#169 [feat] 로그인 상태 전역으로 관리

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -7,12 +7,12 @@ import { Graph, SearchResult } from '@/types/graph/GraphProps';
 import '../../styles/graph.module.css';
 import getGraphData from '@/service/graph/getGraphData';
 import extractSearchIdOnly from '@/hooks/graph/extractIdOnly';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import searchTextState from '@/store/search/searchInput';
 import { usePathname } from 'next/navigation';
 import { getUserData } from '@/service/userService';
 import { setLatestLogin } from '@/service/login/latestLogin';
-import loginState from '@/store/user/login';
+import { loginState } from '@/store/user/login';
 import GalaxyGraph from './components/GalaxyGraph';
 import SearchInput from './components/SearchInput';
 import SearchDropdown from './components/SearchDropdown';
@@ -21,7 +21,8 @@ import ErrorComponent from './components/ErrorComponent';
 
 const Home = () => {
   const setSearchText = useSetRecoilState(searchTextState);
-  const [isLogin, setIsLogin] = useRecoilState(loginState);
+  const setIsLogin = useSetRecoilState(loginState);
+
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
@@ -32,21 +33,6 @@ const Home = () => {
     setSearchText('');
   }, [pathname]);
 
-  useEffect(() => {
-    // NOTE 마지막 로그인 수단: 로그인 소셜 로컬스토리지에 저장
-    setLatestLogin(userData?.results.socialType);
-    // NOTE 로그인 상태 recoil set
-    console.log('현재 login 상태: ', isLogin);
-
-    setIsLogin(prev => {
-      return {
-        ...prev,
-        email: userData?.results.email ?? '',
-        nickname: userData?.results.nickname ?? '',
-        profileImgUrl: userData?.results.profileImgUrl ?? '',
-      };
-    });
-  }, []);
   const { data, isError, isLoading } = useQuery<Graph>({
     queryKey: ['graphData'],
     queryFn: getGraphData,
@@ -56,6 +42,14 @@ const Home = () => {
     queryKey: ['user'],
     queryFn: getUserData,
   });
+
+  useEffect(() => {
+    // NOTE 로그인 성공 시 상태 변경
+    setIsLogin(!!userData?.success);
+    console.log('로그인 성공 여부: ', userData?.success);
+    // NOTE 마지막 로그인 수단: 로그인 소셜 로컬스토리지에 저장
+    setLatestLogin(userData?.results.socialType);
+  }, [userData]);
 
   // FIXME 임시 설정
   if (isLoading) return <LoadingComponent />;

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -12,7 +12,7 @@ import searchTextState from '@/store/search/searchInput';
 import { usePathname } from 'next/navigation';
 import { getUserData } from '@/service/userService';
 import { setLatestLogin } from '@/service/login/latestLogin';
-import { loginState } from '@/store/user/login';
+import { setLoginStateLocalStorage } from '@/service/login/loginState';
 import GalaxyGraph from './components/GalaxyGraph';
 import SearchInput from './components/SearchInput';
 import SearchDropdown from './components/SearchDropdown';
@@ -21,7 +21,6 @@ import ErrorComponent from './components/ErrorComponent';
 
 const Home = () => {
   const setSearchText = useSetRecoilState(searchTextState);
-  const setIsLogin = useSetRecoilState(loginState);
 
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -44,11 +43,10 @@ const Home = () => {
   });
 
   useEffect(() => {
-    // NOTE 로그인 성공 시 상태 변경
-    setIsLogin(!!userData?.success);
-    console.log('로그인 성공 여부: ', userData?.success);
     // NOTE 마지막 로그인 수단: 로그인 소셜 로컬스토리지에 저장
     setLatestLogin(userData?.results.socialType);
+    // NOTE 로그인 상태 새로고침 해도 유지되게 로컬스토리지에 저장
+    setLoginStateLocalStorage(!!userData?.success);
   }, [userData]);
 
   // FIXME 임시 설정

--- a/src/app/login/components/GoogleLogin.tsx
+++ b/src/app/login/components/GoogleLogin.tsx
@@ -5,8 +5,7 @@ import { Button } from '@chakra-ui/react';
 import { FcGoogle } from 'react-icons/fc';
 
 const GoogleLogin = () => {
-  // NOTE 로그인 전용 서버로 연결 (추후 기존 서버로 변경 예정)
-  const link = `${process.env.NEXT_PUBLIC_SERVER_URL}:8080/oauth2/authorization/google`;
+  const link = `${process.env.NEXT_PUBLIC_SERVER_URL}/oauth2/authorization/google`;
   const handleClick = () => {
     window.location.href = link;
   };

--- a/src/app/login/components/KakaoLogin.tsx
+++ b/src/app/login/components/KakaoLogin.tsx
@@ -5,8 +5,7 @@ import { Button } from '@chakra-ui/react';
 import { RiKakaoTalkFill } from 'react-icons/ri';
 
 const KakaoLogin = () => {
-  // NOTE 로그인 전용 서버로 연결 (추후 기존 서버로 변경 예정)
-  const link = `${process.env.NEXT_PUBLIC_SERVER_URL}:8080/oauth2/authorization/kakao`;
+  const link = `${process.env.NEXT_PUBLIC_SERVER_URL}/oauth2/authorization/kakao`;
   const handleClick = () => {
     window.location.href = link;
   };

--- a/src/app/login/components/NaverLogin.tsx
+++ b/src/app/login/components/NaverLogin.tsx
@@ -5,8 +5,7 @@ import { Button } from '@chakra-ui/react';
 import { SiNaver } from 'react-icons/si';
 
 const NaverLogin = () => {
-  // NOTE 로그인 전용 서버로 연결 (추후 기존 서버로 변경 예정)
-  const link = `${process.env.NEXT_PUBLIC_SERVER_URL}:8080/oauth2/authorization/naver`;
+  const link = `${process.env.NEXT_PUBLIC_SERVER_URL}/oauth2/authorization/naver`;
   const handleClick = () => {
     window.location.href = link;
   };

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -24,9 +24,10 @@ import Link from 'next/link';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { AxiosResponse } from 'axios';
 import { IoIosArrowDown, IoIosArrowForward } from 'react-icons/io';
-import { useSetRecoilState } from 'recoil';
-import loginState from '@/store/user/login';
-import deleteCookie from '@/store/user/withdrawal';
+// import { useSetRecoilState } from 'recoil';
+// import { loginState } from '@/store/user/login';
+// import deleteCookie from '@/store/user/withdrawal';
+import { useRouter } from 'next/navigation';
 import {
   deleteUserData,
   getBadgeData,
@@ -35,8 +36,15 @@ import {
   putNickname,
 } from '../../service/userService';
 import MyBadge from './components/MyBadge';
+// import useRequireLogin from '@/hooks/common/useRequireLogin';
 
 const Page = () => {
+  // NOTE 페이지 접근 시 로그아웃 상태라면 /login으로 리다이렉트
+  // const isLogin = useRequireLogin();
+
+  // if (!isLogin) {
+  //   return <div>Loading...</div>;
+  // }
   const queryClient = useQueryClient();
   const { data: userData } = useQuery({
     queryKey: ['user'],
@@ -59,8 +67,6 @@ const Page = () => {
     if (userData?.results.nickname) {
       setOldNickname(userData?.results.nickname);
       setNewNickname(userData?.results.nickname);
-
-      console.log(userData?.results.nickname);
     }
   }, [userData]);
   const toast = useToast();
@@ -105,7 +111,7 @@ const Page = () => {
 
   const { isOpen, onOpen, onClose } = useDisclosure();
   const cancelRef = React.useRef<HTMLButtonElement>(null);
-  const setIsLogin = useSetRecoilState(loginState);
+  const router = useRouter();
 
   // NOTE 회원 탈퇴, 성공 시 메인페이지로 이동
   // TODO 쿠키 삭제
@@ -113,36 +119,32 @@ const Page = () => {
     mutationFn: deleteUserData,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['user'] });
-      setIsLogin(prev => {
-        return {
-          ...prev,
-          email: '',
-          nickname: '',
-          profileImgUrl: '',
-        };
-      });
-      deleteCookie(
-        'StelligenceAccessToken',
-        '/',
-        process.env.NEXT_PUBLIC_SERVER_URL,
-      );
-      deleteCookie(
-        'StelligenceRefreshToken',
-        '/',
-        process.env.NEXT_PUBLIC_SERVER_URL,
-      );
+
+      // TODO 클라이언트에서 쿠키 삭제할 필요 없는지 확인하고 삭제 or 유지
+      // deleteCookie(
+      //   'StelligenceAccessToken',
+      //   '/',
+      //   process.env.NEXT_PUBLIC_SERVER_URL,
+      // );
+      // deleteCookie(
+      //   'StelligenceRefreshToken',
+      //   '/',
+      //   process.env.NEXT_PUBLIC_SERVER_URL,
+      // );
       onClose();
       toast({
         title: '회원탈퇴 완료! 다음에 다시 만나요👋',
         status: 'success',
+        duration: 1000,
         isClosable: true,
       });
-      // FIXME 임시로 href로 함(새로고침 필요) -> router.push로는 안됨
-      window.location.href = 'http://localhost:3000/';
+
+      router.push('/');
     },
     onError: (error: Error) => {
       console.error('회원탈퇴 실패: ', error);
 
+      onClose();
       toast({
         title: '회원탈퇴 실패',
         status: 'error',
@@ -223,14 +225,14 @@ const Page = () => {
         </TitleCard>
         <TitleCard title="북마크">
           <ul className="flex flex-row gap-3 flex-wrap">
-            {bookmarkData?.results?.map(bookmark => {
+            {bookmarkData?.results.bookmarks.map(bookmark => {
               return (
                 // TODO 북마크 삭제 버튼 기능 넣기
                 <li key={bookmark.bookmarkId}>
                   <Tag borderRadius="full" variant="solid" bg="accent.500">
                     <TagLabel fontSize="xs" fontWeight="bold">
                       <Link href={`/stars/${bookmark.documentId}`}>
-                        {bookmark.title}
+                        {bookmark.documentTitle}
                       </Link>
                     </TagLabel>
                     <TagCloseButton />
@@ -251,11 +253,11 @@ const Page = () => {
         </TitleCard>
         <TitleCard title="배지">
           <div className="flex flex-wrap gap-3">
-            {badgeData?.results?.map(badge => {
+            {badgeData?.results.badges.map(badge => {
               return (
                 <MyBadge
                   title={badge.badgeTitle}
-                  image={`/image/${badge.badgeType}.png`}
+                  image={`${process.env.NEXT_PUBLIC_SERVER_URL}${badge.badgeImgUrl}`}
                   key={badge.badgeType}
                 />
               );

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -28,6 +28,7 @@ import { IoIosArrowDown, IoIosArrowForward } from 'react-icons/io';
 // import { loginState } from '@/store/user/login';
 // import deleteCookie from '@/store/user/withdrawal';
 import { useRouter } from 'next/navigation';
+import { removeLoginStateLocalStorage } from '@/service/login/loginState';
 import {
   deleteUserData,
   getBadgeData,
@@ -131,6 +132,7 @@ const Page = () => {
       //   '/',
       //   process.env.NEXT_PUBLIC_SERVER_URL,
       // );
+      removeLoginStateLocalStorage();
       onClose();
       toast({
         title: '회원탈퇴 완료! 다음에 다시 만나요👋',

--- a/src/components/Header/RightNav.tsx
+++ b/src/components/Header/RightNav.tsx
@@ -1,6 +1,6 @@
 import postLogout from '@/service/login/logout';
 import { getMiniProfile } from '@/service/userService';
-import loginState from '@/store/user/login';
+import { loginState } from '@/store/user/login';
 import deleteCookie from '@/store/user/withdrawal';
 import { Avatar, Button, Tooltip, useToast } from '@chakra-ui/react';
 import { useQuery, useMutation } from '@tanstack/react-query';
@@ -13,7 +13,7 @@ import { HiOutlinePencil } from 'react-icons/hi';
 import { useRecoilState } from 'recoil';
 
 const RightNav = () => {
-  const [isLogin, setIsLogin] = useRecoilState(loginState);
+  const [isLogin] = useRecoilState(loginState);
   console.log('header의 현재 로그인 상태: ', isLogin);
 
   const router = useRouter();
@@ -37,7 +37,7 @@ const RightNav = () => {
 
       // NOTE 로그아웃 성공 시 login atom에 null 값 지정 & 메인페이지 이동
       // TODO 쿠키 삭제
-      setIsLogin({ email: '', nickname: '', profileImgUrl: '' });
+      // setIsLogin({ email: '', nickname: '', profileImgUrl: '' });
       deleteCookie(
         'StelligenceAccessToken',
         '/',
@@ -102,7 +102,7 @@ const RightNav = () => {
       </div>
 
       {/* NOTE 로그인 상태라면 미니프로필 & 로그아웃 버튼, 아니라면 로그인 버튼 */}
-      {isLogin.nickname ? (
+      {isLogin ? (
         <div className="flex flex-row gap-4">
           <Button
             variant="link"

--- a/src/components/Header/RightNav.tsx
+++ b/src/components/Header/RightNav.tsx
@@ -7,14 +7,13 @@ import { useQuery, useMutation } from '@tanstack/react-query';
 import { AxiosResponse } from 'axios';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { AiOutlineLogin, AiOutlineLogout } from 'react-icons/ai';
 import { HiOutlinePencil } from 'react-icons/hi';
 import { useRecoilState } from 'recoil';
 
 const RightNav = () => {
-  const [isLogin] = useRecoilState(loginState);
-  console.log('header의 현재 로그인 상태: ', isLogin);
+  const [isLogin, setIsLogin] = useRecoilState(loginState);
 
   const router = useRouter();
   const toast = useToast();
@@ -29,6 +28,10 @@ const RightNav = () => {
     queryFn: getMiniProfile,
   });
 
+  useEffect(() => {
+    setIsLogin(!!miniProfileData?.success);
+  }, [miniProfileData]);
+
   // NOTE 로그아웃 요청
   const logoutMutation = useMutation<AxiosResponse, Error>({
     mutationFn: postLogout,
@@ -37,7 +40,6 @@ const RightNav = () => {
 
       // NOTE 로그아웃 성공 시 login atom에 null 값 지정 & 메인페이지 이동
       // TODO 쿠키 삭제
-      // setIsLogin({ email: '', nickname: '', profileImgUrl: '' });
       deleteCookie(
         'StelligenceAccessToken',
         '/',
@@ -113,7 +115,7 @@ const RightNav = () => {
           >
             <Avatar
               name={miniProfileData?.results.nickname}
-              src={miniProfileData?.results.profileImgUrl}
+              src={`${process.env.NEXT_PUBLIC_SERVER_URL}/${miniProfileData?.results.profileImgUrl}`}
               size="xs"
             />
             <h3 className="text-sm self-center">

--- a/src/components/Login/LoginInterceptor.tsx
+++ b/src/components/Login/LoginInterceptor.tsx
@@ -1,0 +1,39 @@
+import apiClient from '@/service/login/axiosClient';
+import { useToast } from '@chakra-ui/react';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+const LoginInterceptor = () => {
+  const toast = useToast();
+  const router = useRouter();
+
+  useEffect(() => {
+    const interceptorId = apiClient.interceptors.response.use(
+      response => {
+        return response;
+      },
+      error => {
+        // SECTION UnAuthorized: 로그인하지 않은 사용자가 접속했을 때
+        if (error.response && error.response.status === 401) {
+          toast({
+            title: '로그아웃 되었습니다.',
+            description: '다시 로그인 해주세요🚀',
+            status: 'warning',
+            duration: 1000,
+            isClosable: true,
+          });
+          router.push('/login');
+        }
+
+        return Promise.reject(error);
+      },
+    );
+
+    return () => {
+      apiClient.interceptors.response.eject(interceptorId);
+    };
+  }, [router]);
+  return null;
+};
+
+export default LoginInterceptor;

--- a/src/components/Login/LoginInterceptor.tsx
+++ b/src/components/Login/LoginInterceptor.tsx
@@ -1,4 +1,5 @@
 import apiClient from '@/service/login/axiosClient';
+import { removeLoginStateLocalStorage } from '@/service/login/loginState';
 import { useToast } from '@chakra-ui/react';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
@@ -15,6 +16,7 @@ const LoginInterceptor = () => {
       error => {
         // SECTION UnAuthorized: 로그인하지 않은 사용자가 접속했을 때
         if (error.response && error.response.status === 401) {
+          removeLoginStateLocalStorage();
           toast({
             title: '로그아웃 되었습니다.',
             description: '다시 로그인 해주세요🚀',

--- a/src/components/Login/LoginInterceptor.tsx
+++ b/src/components/Login/LoginInterceptor.tsx
@@ -18,7 +18,7 @@ const LoginInterceptor = () => {
         if (error.response && error.response.status === 401) {
           removeLoginStateLocalStorage();
           toast({
-            title: '로그아웃 되었습니다.',
+            title: '로그인이 필요합니다',
             description: '다시 로그인 해주세요🚀',
             status: 'warning',
             duration: 1000,

--- a/src/hooks/common/useRequireLogin.ts
+++ b/src/hooks/common/useRequireLogin.ts
@@ -1,13 +1,16 @@
+import { getLoginStateLocalStorage } from '@/service/login/loginState';
 import { loginState } from '@/store/user/login';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 
 const useRequireLogin = () => {
-  const [isLogin] = useRecoilState(loginState);
+  const [isLogin, setIsLogin] = useRecoilState(loginState);
+  const loginStateLocalStorage = getLoginStateLocalStorage();
   const router = useRouter();
 
   useEffect(() => {
+    setIsLogin(loginStateLocalStorage === 'true');
     if (!isLogin) {
       router.push('/login');
     }

--- a/src/hooks/common/useRequireLogin.ts
+++ b/src/hooks/common/useRequireLogin.ts
@@ -1,0 +1,19 @@
+import { loginState } from '@/store/user/login';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+
+const useRequireLogin = () => {
+  const [isLogin] = useRecoilState(loginState);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLogin) {
+      router.push('/login');
+    }
+  }, [isLogin, router]);
+
+  return isLogin;
+};
+
+export default useRequireLogin;

--- a/src/service/login/axiosClient.ts
+++ b/src/service/login/axiosClient.ts
@@ -1,25 +1,8 @@
 import axios from 'axios';
-import { useRouter } from 'next/router';
 
 const apiClient = axios.create({
   baseURL: `${process.env.NEXT_PUBLIC_SERVER_URL}`,
-  headers: {
-    'Content-Type': 'application/json',
-  },
+  withCredentials: true,
 });
-
-apiClient.interceptors.response.use(
-  response => {
-    return response;
-  },
-  error => {
-    // SECTION UnAuthorized: 로그인하지 않은 사용자가 접속했을 때
-    if (error.response.status === 401) {
-      useRouter().push('/login');
-    }
-
-    return Promise.reject(error);
-  },
-);
 
 export default apiClient;

--- a/src/service/login/axiosClient.ts
+++ b/src/service/login/axiosClient.ts
@@ -2,6 +2,9 @@ import axios from 'axios';
 
 const apiClient = axios.create({
   baseURL: `${process.env.NEXT_PUBLIC_SERVER_URL}`,
+  headers: {
+    'Content-Type': 'application/json',
+  },
   withCredentials: true,
 });
 

--- a/src/service/login/loginState.ts
+++ b/src/service/login/loginState.ts
@@ -1,0 +1,12 @@
+export const setLoginStateLocalStorage = (isLogin: boolean | undefined) => {
+  window.localStorage.setItem('isLogin', JSON.stringify(isLogin));
+};
+
+export const getLoginStateLocalStorage = () => {
+  const isLogin = window.localStorage.getItem('isLogin');
+  return isLogin;
+};
+
+export const removeLoginStateLocalStorage = () => {
+  window.localStorage.removeItem('isLogin');
+};

--- a/src/service/userService.ts
+++ b/src/service/userService.ts
@@ -15,11 +15,14 @@ interface UserResponse {
 interface BookmarkData {
   bookmarkId: number;
   documentId: number;
-  title: string;
+  documentTitle: string;
 }
 interface BadgeData {
   badgeType: string;
   badgeTitle: string;
+  badgeEventCategory: string;
+  badgeDescription: string;
+  badgeImgUrl: string;
 }
 interface MiniProfileData {
   memberId: number;
@@ -29,12 +32,17 @@ interface MiniProfileData {
 interface BookmarkResponse {
   success: boolean;
   message: string;
-  results: BookmarkData[];
+  results: {
+    hasNext: boolean;
+    bookmarks: BookmarkData[];
+  };
 }
 interface BadgeResponse {
   success: boolean;
   message: string;
-  results: BadgeData[];
+  results: {
+    badges: BadgeData[];
+  };
 }
 interface MiniProfileResponse {
   success: boolean;
@@ -106,6 +114,7 @@ export const getMiniProfile = async (): Promise<MiniProfileResponse | null> => {
   }
 };
 
+// NOTE 회원 탈퇴
 export const deleteUserData = async (): Promise<AxiosResponse> => {
   try {
     const response = await apiClient.delete('/api/members/me');

--- a/src/store/user/login.ts
+++ b/src/store/user/login.ts
@@ -1,8 +1,11 @@
 import { atom } from 'recoil';
 
-const loginState = atom({
+export const loginState = atom({
   key: 'loginState',
-  default: { email: '', nickname: '', profileImgUrl: '' },
+  default: false,
 });
 
-export default loginState;
+export const userData = atom({
+  key: 'userData',
+  default: { email: '', nickname: '', profileImgUrl: '' },
+});


### PR DESCRIPTION
## 변경 내용

- apiClient에 withcredential true 설정
- recoil 로그인 상태, 사용자 정보 상태 분리(loginState, userData)
- 메인페이지에서 사용자 정보 조회 후 전역상태로 설정(loginState)
- 로그인 상태 유지되도록 로컬스토리지에서 관리
- 유저 관리 관련 오류 해결
  - 북마크, 배지 데이터 형식 변경
  - 소셜로그인 서버 url 변경

## 특이 사항

- ~~아직 로그인 상태 관련해서 작업이 다 끝나지 않았는데, 백엔드 테스트를 위해서 withcredential 설정을 배포하기 위해 pr 올렸습니다! 머지 돼도 닫지 않고 해당 이슈에서 이어서 작업하겠습니다!~~
- 로그인 상태가 새로고침 해도 유지될 수 있도록 로컬스토리지에 관리하는 것까지 완료했습니다
- 개발 도중에 pr을 올려서 코드 정리가 안 되어 있는 점 양해 부탁드립니다😿🙇‍♀️

## 체크리스트

-   [x] PR 날리기 전에 develop branch pull 받으셨나요?
-   [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
-   [x] 주석 Comment Anchors 컨벤션에 맞추어 다셨나요?

closes #
