### PR TITLE
#171 [feat] 마지막 로그인 수단 보여주기

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,14 +5,23 @@ import KakaoLogin from '@/app/login/components/KakaoLogin';
 import NaverLogin from '@/app/login/components/NaverLogin';
 import { Button, Card, Input } from '@chakra-ui/react';
 import { DM_Serif_Display } from 'next/font/google';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
+import { getLatestLogin } from '@/service/login/latestLogin';
+import styles from '../../styles/login.module.css';
 
 const dm = DM_Serif_Display({ subsets: ['latin'], weight: ['400'] });
 
 const Page = () => {
+  const [latestLogin, setLatestLogin] = useState<string | undefined>('');
+  useEffect(() => {
+    const latestLoginString = getLatestLogin()?.replaceAll('"', '');
+    setLatestLogin(latestLoginString);
+    // console.log({ latestLogin });
+  }, []);
+
   // NOTE 테스트를 위한 로직.
   // TODO 최종에서는 삭제
   const router = useRouter();
@@ -63,9 +72,21 @@ const Page = () => {
       >
         <h1 className="text-center font-bold mb-8 text-2xl">로그인</h1>
         <div className="flex flex-col gap-y-3">
-          <KakaoLogin />
-          <NaverLogin />
-          <GoogleLogin />
+          {['KAKAO', 'NAVER', 'GOOGLE'].map(method => {return (
+            <div className="relative" key={method}>
+              {latestLogin === method && (
+                <div className={styles.latestLoginLabel}>
+                  <div className={styles.triangle} />
+                  <div className="bg-black text-white rounded w-fit px-4 py-2 text-xs font-bold">
+                    마지막으로 로그인했어요
+                  </div>
+                </div>
+              )}
+              {method === 'KAKAO' && <KakaoLogin />}
+              {method === 'NAVER' && <NaverLogin />}
+              {method === 'GOOGLE' && <GoogleLogin />}
+            </div>
+          )})}
         </div>
       </Card>
 

--- a/src/service/login/latestLogin.ts
+++ b/src/service/login/latestLogin.ts
@@ -1,8 +1,8 @@
 export const setLatestLogin = (socialType: string | undefined) => {
-  localStorage.setItem('socialType', JSON.stringify(socialType));
+  window.localStorage.setItem('socialType', JSON.stringify(socialType));
 };
 
 export const getLatestLogin = () => {
-  const socialType = localStorage.getItem('socialType');
+  const socialType = window.localStorage.getItem('socialType');
   return socialType;
 };

--- a/src/styles/login.module.css
+++ b/src/styles/login.module.css
@@ -1,0 +1,18 @@
+.triangle {
+  width: 0;
+  height: 0;
+  border-bottom: 5px solid black;
+  border-top: 5px solid transparent;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  margin: 0 auto;
+}
+.latestLoginLabel {
+  position: absolute;
+  top: 30px;
+  left: 50%;
+  transform: translateX(-50%);
+  flex-direction: column;
+  align-self: center;
+  z-index: 1000;
+}


### PR DESCRIPTION
## 변경 내용

- 마지막 로그인 수단 로컬스토리지에서 socialType 가져와서 해당 타입에 맞는 로그인 버튼에 표시
<img width="356" alt="스크린샷 2024-02-12 오후 3 40 55" src="https://github.com/Eagle-Strike-7/stelligence-frontend/assets/82389864/a8f52b8f-5bab-4672-9ecd-adf1d46dde62">

## 특이 사항

-

## 체크리스트

-   [x] PR 날리기 전에 develop branch pull 받으셨나요?
-   [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
-   [x] 주석 Comment Anchors 컨벤션에 맞추어 다셨나요?

closes #171 
