### PR TITLE
#185 [style] 토론 목록 페이지 다크모드 UI 수정

### DIFF
--- a/src/app/debate-list/components/DebateListCard.tsx
+++ b/src/app/debate-list/components/DebateListCard.tsx
@@ -16,16 +16,17 @@ const DebateListCard: React.FC<ListCardProps<{ commentNum: number }>> = ({
       display="flex"
       mb="1rem"
       width="full"
+      variant="elevated"
+      bg="rgba(118, 147, 231,0.1)"
+      color="white"
       rounded="md"
       padding={4}
       justify="space-between"
       border={2}
-      borderColor="black"
-      colorScheme="blue"
+      borderColor="primary.500"
       direction={{ base: 'column', sm: 'row' }}
-      bg="white"
       _hover={{
-        bg: 'gray.50',
+        bg: 'rgba(118, 147, 231, 0.22)',
         cursor: 'pointer',
       }}
     >

--- a/src/app/debate-list/page.tsx
+++ b/src/app/debate-list/page.tsx
@@ -123,6 +123,7 @@ const Page = () => {
           showLastButton
           className="my-10 mb-20"
           page={currentPage}
+          color="primary"
           onChange={handlePageChange}
         />
       </Center>

--- a/src/components/Common/ChakraSelect.tsx
+++ b/src/components/Common/ChakraSelect.tsx
@@ -22,14 +22,11 @@ const ChakraSelect: React.FC<ChakraSelectProps> = ({
   return (
     <div className="flex my-0">
       <Select
-        variant="outline"
+        variant="fill"
         size="sm"
         rounded="md"
-        // color="text.dark"
-        bg="primary.500"
-        borderColor="primary.500"
-        borderWidth={1}
-        focusBorderColor="primary.400"
+        color="text.dark"
+        bg="#292929"
         fontSize="md"
         fontWeight={500}
         onChange={handleSelectedOption}

--- a/src/components/Common/ChakraSelect.tsx
+++ b/src/components/Common/ChakraSelect.tsx
@@ -22,20 +22,25 @@ const ChakraSelect: React.FC<ChakraSelectProps> = ({
   return (
     <div className="flex my-0">
       <Select
-        variant="filled"
+        variant="outline"
         size="sm"
         rounded="md"
-        borderColor="gray.200"
+        // color="text.dark"
+        bg="primary.500"
+        borderColor="primary.500"
         borderWidth={1}
-        focusBorderColor="gray.400"
-        bg="white"
+        focusBorderColor="primary.400"
+        fontSize="md"
+        fontWeight={500}
         onChange={handleSelectedOption}
       >
-        {options.map(option => {return (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        )})}
+        {options.map(option => {
+          return (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          );
+        })}
       </Select>
     </div>
   );

--- a/src/components/Common/StateTab.tsx
+++ b/src/components/Common/StateTab.tsx
@@ -21,7 +21,8 @@ const StateTab: React.FC<{
         variant="ghost"
         fontSize="lg"
         fontWeight="semibold"
-        color={activeTab === tab1 ? 'black' : 'gray.300'}
+        color="text.dark"
+        opacity={activeTab === tab1 ? '1' : '0.2'}
         mr={4}
         _hover={{ cursor: 'pointer', bg: 'none' }}
         padding={0}
@@ -41,7 +42,8 @@ const StateTab: React.FC<{
         variant="ghost"
         fontSize="lg"
         fontWeight="semibold"
-        color={activeTab === tab2 ? 'black' : 'gray.300'}
+        color="text.dark"
+        opacity={activeTab === tab2 ? '1' : '0.2'}
         mr={4}
         _hover={{ cursor: 'pointer', bg: 'none' }}
         padding={0}

--- a/src/theme/chakra.ts
+++ b/src/theme/chakra.ts
@@ -22,9 +22,9 @@ const customTheme = extendTheme({
       500: '#07063B',
     },
     text: {
-      50: '000000',
-      500: 'AEAEAE',
-      900: 'ffffff',
+      light: '#000000',
+      dark: '#ffffff',
+      500: '#AEAEAE',
     },
     primaryGray: {
       500: '#667799', // 다희님색

--- a/src/theme/mui.ts
+++ b/src/theme/mui.ts
@@ -3,31 +3,25 @@ import { createTheme } from '@mui/material/styles';
 // MUI 테마 설정
 const muiTheme = createTheme({
   palette: {
-    // 기본적인 색상 구성 예시
     primary: {
-      main: '#7693E7', // primary 색상
-      light: '#D0D8FB', // primaryLight 색상
+      main: '#7693E7',
+      light: '#D0D8FB',
     },
     secondary: {
-      main: '#F9AF6C', // secondary 색상
-      light: '#FFD8B7', // secondaryLight 색상
+      main: '#F9AF6C',
+      light: '#FFD8B7',
     },
     error: {
-      main: '#f44336', // 에러 색상 추가 (예시)
+      main: '#f44336',
     },
-    // 커스텀 색상 추가 방법
     background: {
-      default: '#ffffff', // 페이지 기본 배경 색상
-      paper: '#f2f4f6', // 카드 및 컴포넌트 배경 색상
+      default: '#212121',
     },
     text: {
-      primary: '#000000', // 주 텍스트 색상
-      secondary: '#AEAEAE', // 보조 텍스트 색상
+      primary: '#fff', // 주 텍스트 색상
+      secondary: '#000', // 보조 텍스트 색상
       disabled: '#718096', // 비활성 텍스트 색상
     },
-    // 추가적인 커스텀 색상 정의
-    // 여기에 다른 커스텀 색상을 palette에 맞게 추가할 수 있습니다.
-    // 예: customColor: { main: '#...', contrastText: '#...' }
   },
 });
 


### PR DESCRIPTION
## 변경 내용

- 토론 목록 페이지 StateTab 컴포넌트 색상 수정
- chakra select 컴포넌트 색상 수정
- DebateCard 컴포넌트 배경, hover시 색상 수정
- chakra text light, dark로 각각 검정, 흰색 설정
- mui 테마 text 색 설정(primary를 흰색으로 설정, mui 제약)

## 특이 사항

- mui에서는 text 색을 primary, secondary 등 지정된 이름으로만 설정 가능해서 primary를 흰색(#fff)으로 설정함.

## 체크리스트

-   [x] PR 날리기 전에 develop branch pull 받으셨나요?
-   [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
-   [x] 주석 Comment Anchors 컨벤션에 맞추어 다셨나요?

closes #185 
