### PR TITLE
#192 [feat] 토론 종료 후 수정 요청 보내기 기능 구현

### DIFF
--- a/src/app/debate-list/[debateId]/components/NewReviseRequest.tsx
+++ b/src/app/debate-list/[debateId]/components/NewReviseRequest.tsx
@@ -1,7 +1,49 @@
 import { Button } from '@chakra-ui/react';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getCommentList } from '@/service/debate/comment';
+import { useQuery } from '@tanstack/react-query';
+import { getMiniProfile } from '@/service/userService';
 
-const NewReviseRequest = () => {
+const NewReviseRequest: React.FC<{
+  debateId: number;
+  starId: number | undefined;
+  setIsNewReviseRequested: (bool: boolean) => void;
+}> = ({ debateId, starId, setIsNewReviseRequested }) => {
+  const router = useRouter();
+  const [engagedUsers, setEngagedUsers] = useState<string[]>([]);
+  const { data: miniProfileData } = useQuery({
+    queryKey: ['user', 'mini'],
+    queryFn: getMiniProfile,
+  });
+
+  useEffect(() => {
+    getCommentList(debateId)
+      .then(comments => {
+        const nicknames = comments.map(item => {return item.commenter.nickname});
+        setEngagedUsers([...nicknames]);
+      })
+      .catch(error => {
+        console.error('Error fetching comments:', error);
+      });
+  }, [debateId]);
+
+  const handleNewReviseRequestByDebate = () => {
+    // NOTE 수정 요청 권한이 있는 사람만 가능
+    if (
+      miniProfileData &&
+      engagedUsers.includes(miniProfileData!.results.nickname)
+    ) {
+      // NOTE 로컬스토리지에 debateId 저장
+      localStorage.setItem('debateId', debateId.toString());
+      // NOTE 수정 요청 페이지로 이동
+      router.push(`/stars/${starId}/revise`);
+      // NOTE 수정 요청 버튼 이후에 안보이게 -> 백엔드 처리 필요
+      setIsNewReviseRequested(true);
+    } else {
+      alert('수정 요청 권한이 없습니다.');
+    }
+  };
   return (
     <div className="flex text-center place-self-center justify-center mb-4 mt-[-1rem] ">
       <Button
@@ -22,6 +64,7 @@ const NewReviseRequest = () => {
           boxShadow:
             '0 0 1px 2px rgba(88, 144, 255, .75), 0 1px 1px rgba(0, 0, 0, .15)',
         }}
+        onClick={handleNewReviseRequestByDebate}
       >
         새 수정 요청
       </Button>

--- a/src/app/debate-list/[debateId]/page.tsx
+++ b/src/app/debate-list/[debateId]/page.tsx
@@ -17,6 +17,8 @@ const Page = () => {
   const debateId = Number(pathname.split('/').pop());
   const [debateData, setDebateData] = useState<Debate | null>(null);
   const [commentsUpdated, setCommentsUpdated] = useState(false);
+  // TODO 서버로부터 해당 정보 받도록 변경 필요(계속 유지되어야 하는 정보)
+  const [isNewReviseRequested, setIsNewReviseRequested] = useState(false);
 
   useEffect(() => {
     if (debateId) {
@@ -62,7 +64,15 @@ const Page = () => {
           )}
         </div>
       </Tooltip>
-      <NewReviseRequest />
+      {isNewReviseRequested ? (
+        ''
+      ) : (
+        <NewReviseRequest
+          debateId={debateId}
+          starId={debateData?.documentId}
+          setIsNewReviseRequested={setIsNewReviseRequested}
+        />
+      )}
       <DebateDetail debateData={debateData} />
       <CommentList debateId={debateId} commentsUpdated={commentsUpdated} />
       <CommentCreate


### PR DESCRIPTION
## 변경 내용

- 토론 종료 후 새 수정 요청 버튼 클릭 시 수정 요청 페이지로 이동(debateId 저장)
- 수정 요청을 보낼 수 있는 권한이 있는지 댓글 기준으로 확인
- 토론 기반 새 수정 요청을 보낸적 있는지 여부에 따라 버튼 보이기/숨기기 구현(백엔드 수정 필요) 

## 특이 사항

- 새 수정 요청을 보낸적 있는지 확인 하는 부분에 대해 백엔드와 논의 후 수정 필요

## 체크리스트

-   [x] PR 날리기 전에 develop branch pull 받으셨나요?
-   [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
-   [x] 주석 Comment Anchors 컨벤션에 맞추어 다셨나요?

closes #192 
