### PR TITLE
#187 [feat] 토론 내 다른 댓글 태그 기능 구현

### DIFF
--- a/src/app/debate-list/[debateId]/components/Comment/CommentCard.tsx
+++ b/src/app/debate-list/[debateId]/components/Comment/CommentCard.tsx
@@ -49,7 +49,7 @@ const CommentCard: React.FC<DebateCommentProps> = ({
     });
   };
   return (
-    <Box className="flex w-full p-4 my-3 rounded-md bg-primary-dark-500/10 text-white">
+    <Box className="flex w-full p-4 my-2 rounded-md bg-primary-dark-500/10 text-white">
       {isEdit ? (
         <div className="flex flex-col w-full my-2">
           <Textarea
@@ -74,17 +74,18 @@ const CommentCard: React.FC<DebateCommentProps> = ({
         </div>
       ) : (
         <>
-          <div className="flex flex-col justify-center items-center justify-items-center align-middle w-16 mr-4">
+          <div className="flex flex-col justify-center items-center justify-items-center align-middle w-12 mr-4 ">
             <Avatar src={userImg} size="sm" />
           </div>
-          <div className="flex-col w-full">
-            <div className="flex justify-between text-white">
-              <div className="flex place-items-center mb-4 ">
+          <div className="flex-col w-full ">
+            <div className="flex justify-between text-white place-items-center">
+              <div className="flex place-items-baseline my-1">
                 <Tag
                   mr={2}
                   cursor="pointer"
                   verticalAlign="middle"
-                  fontSize="xs"
+                  fontSize="sm"
+                  lineHeight="max"
                 >
                   #{commentId}
                 </Tag>
@@ -109,10 +110,10 @@ const CommentCard: React.FC<DebateCommentProps> = ({
                 />
               </div>
             </div>
-            <div>
+            <div className="my-2">
               <Text>{commentContent}</Text>
             </div>
-            <div className="flex justify-end items-baseline">
+            <div className="flex justify-end items-baseline mt-2">
               <Text className="text-gray-600 text-xs">
                 {time.split('.')[0]}
               </Text>

--- a/src/app/debate-list/[debateId]/components/Comment/CommentCard.tsx
+++ b/src/app/debate-list/[debateId]/components/Comment/CommentCard.tsx
@@ -14,7 +14,7 @@ export interface DebateCommentProps {
   commentId: number;
   commentIds: number[];
   setIsChanged: Dispatch<SetStateAction<boolean>>;
-  handleClickCommentId: (e: any) => void;
+  handleClickCommentId: (e: React.MouseEvent<HTMLSpanElement>) => void;
 }
 
 const CommentCard: React.FC<DebateCommentProps> = ({

--- a/src/app/debate-list/[debateId]/components/Comment/CommentCard.tsx
+++ b/src/app/debate-list/[debateId]/components/Comment/CommentCard.tsx
@@ -12,6 +12,7 @@ export interface DebateCommentProps {
   time: string;
   commentId: number;
   setIsChanged: Dispatch<SetStateAction<boolean>>;
+  handleClickCommentId: (e: any) => void;
 }
 
 const CommentCard: React.FC<DebateCommentProps> = ({
@@ -21,6 +22,7 @@ const CommentCard: React.FC<DebateCommentProps> = ({
   time,
   commentId,
   setIsChanged,
+  handleClickCommentId,
 }) => {
   const pathname = usePathname();
   const debateId = Number(pathname.split('/').pop());
@@ -86,6 +88,11 @@ const CommentCard: React.FC<DebateCommentProps> = ({
                   verticalAlign="middle"
                   fontSize="sm"
                   lineHeight="max"
+                  bg="primary.900"
+                  color="primary.300"
+                  fontWeight={700}
+                  onClick={handleClickCommentId}
+                  id={commentId.toString()}
                 >
                   #{commentId}
                 </Tag>

--- a/src/app/debate-list/[debateId]/components/Comment/CommentCard.tsx
+++ b/src/app/debate-list/[debateId]/components/Comment/CommentCard.tsx
@@ -74,20 +74,25 @@ const CommentCard: React.FC<DebateCommentProps> = ({
         </div>
       ) : (
         <>
-          <Box className="flex flex-col justify-center items-center justify-items-center align-middle w-16 mr-4">
+          <div className="flex flex-col justify-center items-center justify-items-center align-middle w-16 mr-4">
             <Avatar src={userImg} size="sm" />
-          </Box>
-          <Box className="flex-col w-full">
-            <Box className="flex justify-between text-white ">
-              <div className="flex place-items-center mb-4">
-                <Tag mr={2} cursor="pointer" textAlign="center" fontSize="xs">
+          </div>
+          <div className="flex-col w-full">
+            <div className="flex justify-between text-white">
+              <div className="flex place-items-center mb-4 ">
+                <Tag
+                  mr={2}
+                  cursor="pointer"
+                  verticalAlign="middle"
+                  fontSize="xs"
+                >
                   #{commentId}
                 </Tag>
                 <Text fontSize="xs" color="primary.500">
                   {userName}
                 </Text>
               </div>
-              <Box className="flex justify-center align-center">
+              <div className="flex justify-center align-center">
                 <AiTwotoneAlert
                   size="1.25rem"
                   className="mr-1 hover:cursor-pointer"
@@ -102,17 +107,17 @@ const CommentCard: React.FC<DebateCommentProps> = ({
                   className="hover:cursor-pointer"
                   onClick={handleEditComment}
                 />
-              </Box>
-            </Box>
-            <Box>
+              </div>
+            </div>
+            <div>
               <Text>{commentContent}</Text>
-            </Box>
-            <Box className="flex justify-end items-baseline">
+            </div>
+            <div className="flex justify-end items-baseline">
               <Text className="text-gray-600 text-xs">
                 {time.split('.')[0]}
               </Text>
-            </Box>
-          </Box>
+            </div>
+          </div>
         </>
       )}
     </Box>

--- a/src/app/debate-list/[debateId]/components/Comment/CommentCard.tsx
+++ b/src/app/debate-list/[debateId]/components/Comment/CommentCard.tsx
@@ -1,3 +1,4 @@
+import renderContentWithTags from '@/lib/debate/renderContentWithTags';
 import { deleteComment, updateComment } from '@/service/debate/comment';
 import { Avatar, Box, Button, Tag, Text, Textarea } from '@chakra-ui/react';
 import { usePathname } from 'next/navigation';
@@ -11,6 +12,7 @@ export interface DebateCommentProps {
   commentContent: string;
   time: string;
   commentId: number;
+  commentIds: number[];
   setIsChanged: Dispatch<SetStateAction<boolean>>;
   handleClickCommentId: (e: any) => void;
 }
@@ -21,6 +23,7 @@ const CommentCard: React.FC<DebateCommentProps> = ({
   commentContent,
   time,
   commentId,
+  commentIds,
   setIsChanged,
   handleClickCommentId,
 }) => {
@@ -50,6 +53,7 @@ const CommentCard: React.FC<DebateCommentProps> = ({
       return !prev;
     });
   };
+
   return (
     <Box className="flex w-full p-4 my-2 rounded-md bg-primary-dark-500/10 text-white">
       {isEdit ? (
@@ -118,7 +122,7 @@ const CommentCard: React.FC<DebateCommentProps> = ({
               </div>
             </div>
             <div className="my-2">
-              <Text>{commentContent}</Text>
+              <div>{renderContentWithTags(commentContent, commentIds)}</div>
             </div>
             <div className="flex justify-end items-baseline mt-2">
               <Text className="text-gray-600 text-xs">

--- a/src/app/debate-list/[debateId]/components/Comment/CommentCard.tsx
+++ b/src/app/debate-list/[debateId]/components/Comment/CommentCard.tsx
@@ -1,5 +1,5 @@
 import { deleteComment, updateComment } from '@/service/debate/comment';
-import { Avatar, Box, Button, Text, Textarea } from '@chakra-ui/react';
+import { Avatar, Box, Button, Tag, Text, Textarea } from '@chakra-ui/react';
 import { usePathname } from 'next/navigation';
 import React, { Dispatch, SetStateAction, useState } from 'react';
 import { AiOutlineEdit, AiTwotoneAlert } from 'react-icons/ai';
@@ -79,9 +79,14 @@ const CommentCard: React.FC<DebateCommentProps> = ({
           </Box>
           <Box className="flex-col w-full">
             <Box className="flex justify-between text-white ">
-              <Text fontSize="xs" color="primary.500">
-                {userName}
-              </Text>
+              <div className="flex place-items-center mb-4">
+                <Tag mr={2} cursor="pointer" textAlign="center" fontSize="xs">
+                  #{commentId}
+                </Tag>
+                <Text fontSize="xs" color="primary.500">
+                  {userName}
+                </Text>
+              </div>
               <Box className="flex justify-center align-center">
                 <AiTwotoneAlert
                   size="1.25rem"

--- a/src/app/debate-list/[debateId]/components/Comment/CommentCreate.tsx
+++ b/src/app/debate-list/[debateId]/components/Comment/CommentCreate.tsx
@@ -52,25 +52,43 @@ const CommentCreate = ({
             <span className="text-xl font-bold flex-shrink-0 pb-2">댓글</span>
             <HiOutlineChevronDoubleDown
               size={20}
-              onClick={() => {return setIsCommentCreateOpen(false)}}
+              onClick={() => {
+                return setIsCommentCreateOpen(false);
+              }}
               className="hover:cursor-pointer"
               color="primary.500"
             />
           </div>
           <Textarea
             className="w-full my-3 flex-shrink-0"
-            bg="white"
+            bg="#292929"
             marginBottom={8}
+            border="none"
             placeholder="댓글을 여기에 입력해주세요 :)"
             value={newContent}
-            onChange={e => {return setNewContent(e.target.value)}}
+            onChange={e => {
+              return setNewContent(e.target.value);
+            }}
           />
           <Button
             className="w-20 self-end"
             size="sm"
             bg="primary.500"
-            color="white"
+            color="text.light"
             marginBottom={6}
+            _hover={{
+              bg: 'rgba(118, 147, 231, 0.7)', // 'primary.500'에 해당하는 RGBA 값
+              color: 'white',
+              transition: 'background-color 0.5s ease',
+            }}
+            _active={{
+              bg: 'rgba(118, 147, 231, 0.5)',
+              transition: 'background-color 0.2s ease',
+            }}
+            _focus={{
+              boxShadow:
+                '0 0 1px 2px rgba(88, 144, 255, .75), 0 1px 1px rgba(0, 0, 0, .15)',
+            }}
             onClick={submitComment}
           >
             댓글달기
@@ -85,7 +103,9 @@ const CommentCreate = ({
         <HiOutlineChevronDoubleUp
           className="hover:cursor-pointer"
           size={20}
-          onClick={() => {return setIsCommentCreateOpen(true)}}
+          onClick={() => {
+            return setIsCommentCreateOpen(true);
+          }}
         />
       </div>
     );

--- a/src/app/debate-list/[debateId]/components/Comment/CommentCreate.tsx
+++ b/src/app/debate-list/[debateId]/components/Comment/CommentCreate.tsx
@@ -1,26 +1,103 @@
-import React, { useState } from 'react';
-import { postNewComment } from '@/service/debate/comment';
+import React, { useEffect, useRef, useState } from 'react';
+import { getCommentList, postNewComment } from '@/service/debate/comment';
 import scrollToBottom from '@/lib/debate/scrollToBottom';
 import { Button, Textarea } from '@chakra-ui/react';
 import {
   HiOutlineChevronDoubleDown,
   HiOutlineChevronDoubleUp,
 } from 'react-icons/hi';
+import CommentDropdownMenu from './CommentDropdownMenu';
 
 interface CommentCreateProps {
   onCommentCreated: () => void;
   debateId: number;
   debateStatus: 'OPEN' | 'CLOSED' | null;
+  handleClickCommentId: (e: any) => void;
+  selectedCommentId: string;
 }
 const CommentCreate = ({
   onCommentCreated,
   debateId,
   debateStatus,
+  selectedCommentId,
+  handleClickCommentId,
 }: CommentCreateProps) => {
+  const textareaRef = useRef(null);
   const [isCreateCommentOpen, setIsCommentCreateOpen] = useState<boolean>(true);
   const [newContent, setNewContent] = useState<string>('');
+  const [commentIds, setCommentIds] = useState<number[]>([]);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const [cursorPosition, setCursorPosition] = useState({ top: 0, left: 0 });
 
-  const submitComment = () => {
+  // NOTE useEffect 로직
+  useEffect(() => {
+    getCommentList(debateId)
+      .then(comments => {
+        setCommentIds(comments.map(item => {return item.commentId}));
+      })
+      .catch(error => {
+        console.error('Error fetching comments:', error);
+      });
+  }, [debateId]);
+
+  useEffect(() => {
+    if (selectedCommentId) {
+      const lastInputValue = newContent.charAt(newContent.length - 1);
+      if (lastInputValue === '#') {
+        setNewContent(prevContent => {return `${prevContent + selectedCommentId  } `});
+      } else {
+        const additionalSpace =
+          newContent && !newContent.endsWith(' ') ? ' ' : '';
+        setNewContent(
+          prevContent =>
+            {return `${prevContent}${additionalSpace}#${selectedCommentId} `},
+        );
+      }
+    }
+  }, [selectedCommentId]); // newContent를 의존성 배열에서 제거
+
+  // NOTE 커서 위치 기반으로 드롭다운 위치 계산하는 함수
+  const calculateDropdownPosition = (textarea: HTMLTextAreaElement) => {
+    const text = textarea.value;
+    const cursorIndex = textarea.selectionStart;
+    const lineNumber = text.substr(0, cursorIndex).split('\n').length;
+    const lineHeight = parseInt(getComputedStyle(textarea).lineHeight, 10);
+    const currentLineText = text.substr(0, cursorIndex).split('\n').pop();
+    const charWidth = parseInt(getComputedStyle(textarea).fontSize, 10) * 0.6;
+    const additionalLeftOffset = 15;
+    const approximateLeft = currentLineText
+      ? currentLineText.length * charWidth + additionalLeftOffset
+      : 10;
+    const additionalOffset = 30;
+    const approximateTop =
+      (lineNumber - 1) * lineHeight + textarea.offsetTop + additionalOffset;
+
+    setCursorPosition({ top: approximateTop, left: approximateLeft });
+  };
+
+  // NOTE textarea값 바뀔 때마다 호출되는 함수
+  const handleChangeInput = (e: any) => {
+    const textarea = e.target;
+    setNewContent(textarea.value);
+
+    // '#'이 포함되어 있는지 확인하고 드롭다운 표시 여부 결정
+    const hasHashOrHashAndNumber = /#$|#\d+$/.test(textarea.value);
+    if (hasHashOrHashAndNumber) {
+      setShowDropdown(true);
+    } else {
+      setShowDropdown(false);
+    }
+    calculateDropdownPosition(textarea);
+  };
+
+  // NOTE 드롭다운 후보 댓글 클릭 시 동작하는 함수
+  const handleClickDropdownComment = (e: React.MouseEvent<HTMLSpanElement>) => {
+    handleClickCommentId(e);
+    setShowDropdown(false);
+  };
+
+  // NOTE 댓글 작성 제출 함수
+  const handleSubmitComment = () => {
     postNewComment(newContent, debateId)
       .then(() => {
         onCommentCreated();
@@ -49,7 +126,10 @@ const CommentCreate = ({
       return (
         <>
           <div className="flex flex-row justify-between align-center w-full mt-3">
-            <span className="text-xl font-bold flex-shrink-0 pb-2">댓글</span>
+            <div className="relative inline-block">
+              <span className="text-xl font-bold flex-shrink-0 pb-2">댓글</span>
+            </div>
+
             <HiOutlineChevronDoubleDown
               size={20}
               onClick={() => {
@@ -59,17 +139,38 @@ const CommentCreate = ({
               color="primary.500"
             />
           </div>
+
           <Textarea
+            ref={textareaRef}
             className="w-full my-3 flex-shrink-0"
             bg="#292929"
             marginBottom={8}
             border="none"
             placeholder="댓글을 여기에 입력해주세요 :)"
             value={newContent}
-            onChange={e => {
-              return setNewContent(e.target.value);
-            }}
+            onChange={handleChangeInput}
+            onClick={handleChangeInput} // 커서 이동 시에도 위치 업데이트
+            style={{ lineHeight: '20px' }}
           />
+
+          {newContent.length > 0 && showDropdown && (
+            <div
+              style={{
+                position: 'absolute',
+                top: `${cursorPosition.top}px`,
+                left: `${cursorPosition.left}px`,
+                backgroundColor: 'white',
+              }}
+            >
+              {commentIds.length > 0 && (
+                <CommentDropdownMenu
+                  items={commentIds}
+                  handleClickDropdownComment={handleClickDropdownComment}
+                />
+              )}
+            </div>
+          )}
+
           <Button
             className="w-20 self-end"
             size="sm"
@@ -89,7 +190,7 @@ const CommentCreate = ({
               boxShadow:
                 '0 0 1px 2px rgba(88, 144, 255, .75), 0 1px 1px rgba(0, 0, 0, .15)',
             }}
-            onClick={submitComment}
+            onClick={handleSubmitComment}
           >
             댓글달기
           </Button>

--- a/src/app/debate-list/[debateId]/components/Comment/CommentCreate.tsx
+++ b/src/app/debate-list/[debateId]/components/Comment/CommentCreate.tsx
@@ -13,7 +13,7 @@ interface CommentCreateProps {
   debateId: number;
   commentIds: number[];
   debateStatus: 'OPEN' | 'CLOSED' | null;
-  handleClickCommentId: (e: any) => void;
+  handleClickCommentId: (e: React.MouseEvent<HTMLSpanElement>) => void;
   selectedCommentId: string;
 }
 const CommentCreate = ({

--- a/src/app/debate-list/[debateId]/components/Comment/CommentCreate.tsx
+++ b/src/app/debate-list/[debateId]/components/Comment/CommentCreate.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { getCommentList, postNewComment } from '@/service/debate/comment';
+import { postNewComment } from '@/service/debate/comment';
 import scrollToBottom from '@/lib/debate/scrollToBottom';
 import { Button, Textarea } from '@chakra-ui/react';
 import {
@@ -11,6 +11,7 @@ import CommentDropdownMenu from './CommentDropdownMenu';
 interface CommentCreateProps {
   onCommentCreated: () => void;
   debateId: number;
+  commentIds: number[];
   debateStatus: 'OPEN' | 'CLOSED' | null;
   handleClickCommentId: (e: any) => void;
   selectedCommentId: string;
@@ -21,37 +22,27 @@ const CommentCreate = ({
   debateStatus,
   selectedCommentId,
   handleClickCommentId,
+  commentIds,
 }: CommentCreateProps) => {
   const textareaRef = useRef(null);
   const [isCreateCommentOpen, setIsCommentCreateOpen] = useState<boolean>(true);
   const [newContent, setNewContent] = useState<string>('');
-  const [commentIds, setCommentIds] = useState<number[]>([]);
   const [showDropdown, setShowDropdown] = useState(false);
   const [cursorPosition, setCursorPosition] = useState({ top: 0, left: 0 });
-
-  // NOTE useEffect 로직
-  useEffect(() => {
-    getCommentList(debateId)
-      .then(comments => {
-        setCommentIds(comments.map(item => {return item.commentId}));
-      })
-      .catch(error => {
-        console.error('Error fetching comments:', error);
-      });
-  }, [debateId]);
 
   useEffect(() => {
     if (selectedCommentId) {
       const lastInputValue = newContent.charAt(newContent.length - 1);
       if (lastInputValue === '#') {
-        setNewContent(prevContent => {return `${prevContent + selectedCommentId  } `});
+        setNewContent(prevContent => {
+          return `${prevContent + selectedCommentId} `;
+        });
       } else {
         const additionalSpace =
           newContent && !newContent.endsWith(' ') ? ' ' : '';
-        setNewContent(
-          prevContent =>
-            {return `${prevContent}${additionalSpace}#${selectedCommentId} `},
-        );
+        setNewContent(prevContent => {
+          return `${prevContent}${additionalSpace}#${selectedCommentId} `;
+        });
       }
     }
   }, [selectedCommentId]); // newContent를 의존성 배열에서 제거

--- a/src/app/debate-list/[debateId]/components/Comment/CommentDropdownMenu.tsx
+++ b/src/app/debate-list/[debateId]/components/Comment/CommentDropdownMenu.tsx
@@ -1,0 +1,26 @@
+import { Tag } from '@chakra-ui/react';
+
+const CommentDropdownMenu: React.FC<{
+  items: number[];
+  handleClickDropdownComment: (e: React.MouseEvent<HTMLSpanElement>) => void;
+}> = ({ items, handleClickDropdownComment }) => {
+  return (
+    <div className="flex-col absolute py-2 px-3 mt-1 rounded-md shadow-lg z-10 flex gap-2 bg-primary-dark-500/20 ">
+      {items.map(item => {return (
+        <Tag
+          className="px-2 py-1 hover:bg-gray-100 cursor-pointer"
+          key={item}
+          bg="primary.900"
+          color="primary.300"
+          fontWeight={700}
+          id={item.toString()}
+          onClick={handleClickDropdownComment}
+        >
+          #{item}
+        </Tag>
+      )})}
+    </div>
+  );
+};
+
+export default CommentDropdownMenu;

--- a/src/app/debate-list/[debateId]/components/Comment/CommentList.tsx
+++ b/src/app/debate-list/[debateId]/components/Comment/CommentList.tsx
@@ -6,10 +6,12 @@ import Comment from './CommentCard';
 interface CommentListProps {
   debateId: number;
   commentsUpdated: boolean;
+  handleClickCommentId: (e: any) => void;
 }
 const CommentList: React.FC<CommentListProps> = ({
   debateId,
   commentsUpdated,
+  handleClickCommentId,
 }) => {
   const [commentList, setCommentList] = useState<CommentProps[]>([]);
   const [isChanged, setIsChanged] = useState<boolean>(false);
@@ -42,6 +44,7 @@ const CommentList: React.FC<CommentListProps> = ({
               commentContent={comment.content}
               time={comment.createdAt.replace('T', ' ')}
               setIsChanged={setIsChanged}
+              handleClickCommentId={handleClickCommentId}
             />
           );
         })}

--- a/src/app/debate-list/[debateId]/components/Comment/CommentList.tsx
+++ b/src/app/debate-list/[debateId]/components/Comment/CommentList.tsx
@@ -5,11 +5,13 @@ import Comment from './CommentCard';
 
 interface CommentListProps {
   debateId: number;
+  commentIds: number[];
   commentsUpdated: boolean;
   handleClickCommentId: (e: any) => void;
 }
 const CommentList: React.FC<CommentListProps> = ({
   debateId,
+  commentIds,
   commentsUpdated,
   handleClickCommentId,
 }) => {
@@ -43,6 +45,7 @@ const CommentList: React.FC<CommentListProps> = ({
               commentId={comment.commentId}
               commentContent={comment.content}
               time={comment.createdAt.replace('T', ' ')}
+              commentIds={commentIds}
               setIsChanged={setIsChanged}
               handleClickCommentId={handleClickCommentId}
             />

--- a/src/app/debate-list/[debateId]/components/Comment/CommentList.tsx
+++ b/src/app/debate-list/[debateId]/components/Comment/CommentList.tsx
@@ -7,7 +7,7 @@ interface CommentListProps {
   debateId: number;
   commentIds: number[];
   commentsUpdated: boolean;
-  handleClickCommentId: (e: any) => void;
+  handleClickCommentId: (e: React.MouseEvent<HTMLSpanElement>) => void;
 }
 const CommentList: React.FC<CommentListProps> = ({
   debateId,

--- a/src/app/debate-list/[debateId]/page.tsx
+++ b/src/app/debate-list/[debateId]/page.tsx
@@ -68,7 +68,7 @@ const Page = () => {
       <CommentCreate
         onCommentCreated={refreshComments}
         debateId={debateId}
-        debateStatus={debateData?.status ?? null}
+        debateStatus={debateData?.status ?? 'OPEN'}
       />
     </Wrapper>
   );

--- a/src/app/debate-list/[debateId]/page.tsx
+++ b/src/app/debate-list/[debateId]/page.tsx
@@ -5,6 +5,7 @@ import Wrapper from '@/components/Common/Wrapper';
 import { usePathname } from 'next/navigation';
 import PageTitleDescription from '@/components/Common/PageTitleDescription';
 import { Tooltip } from '@chakra-ui/react';
+import { getCommentList } from '@/service/debate/comment';
 import { Debate, getDebateData } from './page.server';
 import CommentList from './components/Comment/CommentList';
 import CommentCreate from './components/Comment/CommentCreate';
@@ -18,10 +19,18 @@ const Page = () => {
   const [debateData, setDebateData] = useState<Debate | null>(null);
   const [commentsUpdated, setCommentsUpdated] = useState(false);
   const [selectedCommentId, setSelectedCommentId] = useState<string>('');
+  const [commentIds, setCommentIds] = useState<number[]>([]);
 
   useEffect(() => {
     if (debateId) {
       getDebateData(debateId).then(setDebateData);
+      getCommentList(debateId).then(comments => {
+        setCommentIds(
+          comments.map(item => {
+            return item.commentId;
+          }),
+        );
+      });
     }
   }, [debateId]);
 
@@ -71,6 +80,7 @@ const Page = () => {
       <DebateDetail debateData={debateData} />
       <CommentList
         debateId={debateId}
+        commentIds={commentIds}
         commentsUpdated={commentsUpdated}
         handleClickCommentId={handleClickCommentId}
       />
@@ -78,6 +88,7 @@ const Page = () => {
         selectedCommentId={selectedCommentId}
         onCommentCreated={refreshComments}
         debateId={debateId}
+        commentIds={commentIds}
         debateStatus={debateData?.status ?? 'OPEN'}
         handleClickCommentId={handleClickCommentId}
       />

--- a/src/app/debate-list/[debateId]/page.tsx
+++ b/src/app/debate-list/[debateId]/page.tsx
@@ -17,6 +17,7 @@ const Page = () => {
   const debateId = Number(pathname.split('/').pop());
   const [debateData, setDebateData] = useState<Debate | null>(null);
   const [commentsUpdated, setCommentsUpdated] = useState(false);
+  const [selectedCommentId, setSelectedCommentId] = useState<string>('');
 
   useEffect(() => {
     if (debateId) {
@@ -28,6 +29,10 @@ const Page = () => {
     setCommentsUpdated(prev => {
       return !prev;
     });
+  };
+
+  const handleClickCommentId = (e: React.MouseEvent<HTMLSpanElement>) => {
+    setSelectedCommentId(e.currentTarget.id);
   };
 
   return (
@@ -64,11 +69,17 @@ const Page = () => {
       </Tooltip>
       <NewReviseRequest />
       <DebateDetail debateData={debateData} />
-      <CommentList debateId={debateId} commentsUpdated={commentsUpdated} />
+      <CommentList
+        debateId={debateId}
+        commentsUpdated={commentsUpdated}
+        handleClickCommentId={handleClickCommentId}
+      />
       <CommentCreate
+        selectedCommentId={selectedCommentId}
         onCommentCreated={refreshComments}
         debateId={debateId}
         debateStatus={debateData?.status ?? 'OPEN'}
+        handleClickCommentId={handleClickCommentId}
       />
     </Wrapper>
   );

--- a/src/lib/debate/renderContentWithTags.tsx
+++ b/src/lib/debate/renderContentWithTags.tsx
@@ -1,0 +1,48 @@
+import { Tag } from '@chakra-ui/react';
+import { ReactNode } from 'react';
+
+// NOTE 태그 포함해서 렌더링 하는 함수
+const renderContentWithTags = (
+  commentContent: string,
+  commentIds: number[],
+): ReactNode[] => {
+  const regex = /#(\d+)/g;
+  let match: RegExpExecArray | null;
+  let lastIndex = 0;
+  const elements: ReactNode[] = [];
+
+  match = regex.exec(commentContent);
+  while (match !== null) {
+    const matchIndex = match.index;
+    const matchText = match[0];
+    const id = parseInt(match[1], 10);
+
+    if (matchIndex > lastIndex) {
+      elements.push(commentContent.substring(lastIndex, matchIndex));
+    }
+
+    if (commentIds.includes(id)) {
+      elements.push(
+        <Tag
+          key={matchIndex}
+          bg="primary.900"
+          color="primary.300"
+          fontWeight={700}
+        >
+          {matchText}
+        </Tag>,
+      );
+    } else {
+      elements.push(matchText);
+    }
+    lastIndex = matchIndex + matchText.length;
+    match = regex.exec(commentContent);
+  }
+  if (lastIndex < commentContent.length) {
+    elements.push(commentContent.substring(lastIndex));
+  }
+
+  return elements;
+};
+
+export default renderContentWithTags;


### PR DESCRIPTION
## 변경 내용

- 토론 작성 시 '#' 입력 시 다른 댓글 드롭다운으로 렌더링 
  - 이때 해당 드롭다운 번호 클릭 시 입력창에 댓글 태그 자동 완성
- 토론 존재하는 댓글의 id값 클릭 시 입력창에 댓글 태그 자동 완성
- CommentCard 리팩토링
  - Box -> div로
  - UI 수정
- 댓글 입력 창 UI 수정
- 댓글 목록 id 값 받아오는 부분 코드 리팩토링

## 특이 사항

- 기능이 생각보다 여러 부분에 걸쳐 있어서 코드 변화가 많았습니다.

## 체크리스트

-   [x] PR 날리기 전에 develop branch pull 받으셨나요?
-   [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
-   [x] 주석 Comment Anchors 컨벤션에 맞추어 다셨나요?

closes #187 
