### PR TITLE
#210 [fix] 토론 상세페이지 조회 api 수정 반영, 토론 제목/상위계층태그 변경 사항 수정사항에 추가 렌더링

### DIFF
--- a/src/app/debate-list/[debateId]/components/Carousel/DebateSlider.tsx
+++ b/src/app/debate-list/[debateId]/components/Carousel/DebateSlider.tsx
@@ -61,12 +61,12 @@ const DebateSlider = ({ amendments }: AmendmentsProps) => {
                 <div className="tiptap flex justify-between gap-5">
                   <div className="w-1/2">
                     <StarContent
-                      content={`${amendment.targetSection.title} ${amendment.targetSection.content}`}
+                      content={`<b>${amendment.targetSection.title}</b> <br/> ${amendment.targetSection.content}`}
                     />
                   </div>
                   <div className="w-1/2">
                     <StarContent
-                      content={`${amendment.requestedSectionTitle} ${amendment.requestedSectionContent}`}
+                      content={`<b>${amendment.requestedSectionTitle}</b> <br/> ${amendment.requestedSectionContent}`}
                     />
                   </div>
                 </div>

--- a/src/app/debate-list/[debateId]/components/DebateDetail.tsx
+++ b/src/app/debate-list/[debateId]/components/DebateDetail.tsx
@@ -13,9 +13,9 @@ const DebateDetail: React.FC<DeabteDetailProps> = ({ debateData }) => {
     <div className="flex-col ">
       {debateData && (
         <div
-          className={`flex flex-col px-10 pt-8 pb-20 rounded-lg text-white border-2 border-primary-dark-500/20 mb-10 ${debateData.status === 'CLOSED' ? 'opacity-80' : ''}`}
+          className={`flex flex-col px-10 pt-8 pb-20 rounded-lg text-white border-2 border-primary-dark-500/20 mb-10 ${debateData.status === 'CLOSED' ? 'opacity-60' : ''}`}
         >
-          <DebateInformation debateData={debateData} />
+          <DebateInformation contributeData={debateData.contribute} />
           <div className="mt-10 my-5">
             <MiddleTitle title="수정 요청 사항" color="white" />
             <div className="tiptap flex justify-between gap-5 text-primary-dark-500 ">
@@ -23,7 +23,7 @@ const DebateDetail: React.FC<DeabteDetailProps> = ({ debateData }) => {
               <p className="font-bold w-1/2 text-center mb-4">수정 후</p>
             </div>
           </div>
-          <DebateSlider amendments={debateData.amendments} />
+          <DebateSlider amendments={debateData.contribute.amendments} />
         </div>
       )}
     </div>

--- a/src/app/debate-list/[debateId]/components/DebateDetail.tsx
+++ b/src/app/debate-list/[debateId]/components/DebateDetail.tsx
@@ -1,14 +1,50 @@
-import React from 'react';
-import { Debate } from '../page.server';
+import React, { useEffect, useState } from 'react';
+import { Amendment } from '@/types/common/Amendment';
+import transTitleTagtoAmendment from '@/lib/debate/transTitleAndTagChanged';
 import DebateInformation from './DebateInformation';
 import DebateSlider from './Carousel/DebateSlider';
 import MiddleTitle from './MiddleTitle';
+import { Debate } from '../page.server';
 
 interface DeabteDetailProps {
   debateData: Debate | null;
 }
 
 const DebateDetail: React.FC<DeabteDetailProps> = ({ debateData }) => {
+  const [totalAmendments, setTotalAmendments] = useState<Amendment[]>();
+  useEffect(() => {
+    setTotalAmendments(debateData?.contribute.amendments || []);
+
+    const handleAmendment = (
+      changedType: 'title' | 'tag',
+      before: string,
+      after: string,
+    ) => {
+      if (before !== after) {
+        const newAmendment = transTitleTagtoAmendment(
+          changedType,
+          before,
+          after,
+        );
+        setTotalAmendments(current => {return [newAmendment, ...(current || [])]});
+      }
+    };
+
+    if (debateData) {
+      handleAmendment(
+        'title',
+        debateData.contribute.beforeDocumentTitle,
+        debateData.contribute.afterDocumentTitle,
+      );
+
+      handleAmendment(
+        'tag',
+        debateData.contribute.beforeParentDocumentTitle,
+        debateData.contribute.afterParentDocumentTitle,
+      );
+    }
+  }, [debateData]);
+
   return (
     <div className="flex-col ">
       {debateData && (
@@ -23,7 +59,7 @@ const DebateDetail: React.FC<DeabteDetailProps> = ({ debateData }) => {
               <p className="font-bold w-1/2 text-center mb-4">수정 후</p>
             </div>
           </div>
-          <DebateSlider amendments={debateData.contribute.amendments} />
+          {totalAmendments && <DebateSlider amendments={totalAmendments} />}
         </div>
       )}
     </div>

--- a/src/app/debate-list/[debateId]/components/DebateInformation.tsx
+++ b/src/app/debate-list/[debateId]/components/DebateInformation.tsx
@@ -27,7 +27,7 @@ const DebateInformation = ({
           <h3 className="font-bold text-md w-36 text-white">상위계층태그</h3>
           {contributeData.parentDocumentTitle ? (
             <Tag className="text-md  text-black">
-              {contributeData.parentDocumentTitle}
+              {contributeData.beforeParentDocumentTitle}
             </Tag>
           ) : (
             'X'

--- a/src/app/debate-list/[debateId]/components/DebateInformation.tsx
+++ b/src/app/debate-list/[debateId]/components/DebateInformation.tsx
@@ -1,42 +1,52 @@
 import React from 'react';
 import LabelText from '@/components/Common/LabelText';
 import { Tag } from '@chakra-ui/react';
-import { Debate } from '../page.server';
+import { Contribute } from '@/types/common/Amendment';
+import calculateRemainTime from '@/lib/calculateRemainTime';
 import MiddleTitle from './MiddleTitle';
 
 // TODO ReviseInformation과 통일
-const DebateInformation = ({ debateData }: { debateData: Debate }) => {
+const DebateInformation = ({
+  contributeData,
+}: {
+  contributeData: Contribute;
+}) => {
+  const leftDebateTime = calculateRemainTime(contributeData.endAt);
   return (
     <div className="flex flex-col gap-8 mb-4">
       <MiddleTitle title="개요" color="white" />
       <div className="grid grid-cols-2 gap-4">
         <LabelText
           label="수정 요청안 제목"
-          text={debateData.contributeTitle || '수정요청안 제목'}
+          text={contributeData.contributeTitle || 'X'}
         />
       </div>
       <div className="grid grid-cols-2 gap-4">
-        <LabelText label="글제목" text="sss" />
-        <LabelText
-          label="상위 계층 태그"
-          text={`${debateData.documentId}` || '상위 계층 태그'}
-        />
+        <LabelText label="글제목" text={contributeData.documentTitle} />
+        <div className="flex">
+          <h3 className="font-bold text-md w-36 text-white">상위계층태그</h3>
+          {contributeData.parentDocumentTitle ? (
+            <Tag className="text-md  text-black">
+              {contributeData.parentDocumentTitle}
+            </Tag>
+          ) : (
+            'X'
+          )}
+        </div>
       </div>
 
       <div className="grid grid-cols-2 gap-4">
         <LabelText
           label="수정 요청자"
-          text={debateData.contributor?.nickname || '수정요청자'}
+          text={contributeData.contributor.nickname || 'X'}
         />
-        <div className="flex">
-          <h3 className="font-bold text-md w-36 text-white">남은토론시간</h3>
-          <Tag className="text-md  text-black">2시간</Tag>
-        </div>
+
+        <LabelText label="남은 토론 시간" text={leftDebateTime || 'X'} />
       </div>
 
       <LabelText
         label="수정 요청 이유"
-        text="asfadskfjlsadjflskajdflsajfdlskajdlkjslkfjdlskjflskdjflksjlkssfljsdlfkjalskdfjsaljflsjflksjdflksj sdjflksjflsjdlfsjflkdsjl"
+        text={contributeData.contributeDescription || 'X'}
       />
     </div>
   );

--- a/src/app/debate-list/[debateId]/components/NewReviseRequest.tsx
+++ b/src/app/debate-list/[debateId]/components/NewReviseRequest.tsx
@@ -5,7 +5,7 @@ import { getCommentList } from '@/service/debate/comment';
 import { useQuery } from '@tanstack/react-query';
 import { getMiniProfile } from '@/service/userService';
 
-const NewReviseRequest: React.FC<{
+const NewReviseRequestButton: React.FC<{
   debateId: number;
   starId: number | undefined;
   setIsNewReviseRequested: (bool: boolean) => void;
@@ -58,13 +58,9 @@ const NewReviseRequest: React.FC<{
           color: 'white',
           transition: 'background-color 0.5s ease',
         }}
-        _active={{
-          bg: 'rgba(118, 147, 231, 0.5)',
-          transition: 'background-color 0.2s ease',
-        }}
         _focus={{
           boxShadow:
-            '0 0 1px 2px rgba(88, 144, 255, 0.75), 0 1px 1px rgba(0, 0, 0, .15)',
+            '0 0 1px 2px rgba(88, 144, 255, 0.75), 0 1px 1px rgba(0, 0, 0, 0.15)',
         }}
         onClick={handleNewReviseRequestByDebate}
       >
@@ -74,4 +70,4 @@ const NewReviseRequest: React.FC<{
   );
 };
 
-export default NewReviseRequest;
+export default NewReviseRequestButton;

--- a/src/app/debate-list/[debateId]/components/NewReviseRequest.tsx
+++ b/src/app/debate-list/[debateId]/components/NewReviseRequest.tsx
@@ -20,7 +20,9 @@ const NewReviseRequest: React.FC<{
   useEffect(() => {
     getCommentList(debateId)
       .then(comments => {
-        const nicknames = comments.map(item => {return item.commenter.nickname});
+        const nicknames = comments.map(item => {
+          return item.commenter.nickname;
+        });
         setEngagedUsers([...nicknames]);
       })
       .catch(error => {
@@ -62,7 +64,7 @@ const NewReviseRequest: React.FC<{
         }}
         _focus={{
           boxShadow:
-            '0 0 1px 2px rgba(88, 144, 255, .75), 0 1px 1px rgba(0, 0, 0, .15)',
+            '0 0 1px 2px rgba(88, 144, 255, 0.75), 0 1px 1px rgba(0, 0, 0, .15)',
         }}
         onClick={handleNewReviseRequestByDebate}
       >

--- a/src/app/debate-list/[debateId]/page.server.tsx
+++ b/src/app/debate-list/[debateId]/page.server.tsx
@@ -1,22 +1,13 @@
 import axios from 'axios';
-import { Amendment, Contributor } from '@/types/common/Amendment';
+import { Contribute } from '@/types/common/Amendment';
 
 export interface Debate {
   debateId: number;
   createdAt: string;
   endAt: string;
-  documentId: number;
-  documentTitle: string;
-  contributor: Contributor;
-  contributeId: number;
-  contributeTitle: string;
-  contributeDescription: string;
-  amendments: Amendment[];
-  prevDebate?: Debate;
-  nextDebate?: Debate;
   status: 'OPEN' | 'CLOSED';
+  contribute: Contribute;
 }
-
 export interface DebateDetailApiResponse {
   success: boolean;
   message: string;

--- a/src/app/debate-list/[debateId]/page.tsx
+++ b/src/app/debate-list/[debateId]/page.tsx
@@ -54,13 +54,13 @@ const Page = () => {
           <PageTitleDescription
             title="토론하기"
             description="토론에 참여해보세요"
-            relatedDebateId={debateId}
+            relatedDebateId={debateData.contribute.relatedDebateId}
           />
         ) : (
           <PageTitleDescription
             title="토론결과"
             description="종료된 토론의 결과를 확인하세요."
-            relatedDebateId={debateId}
+            relatedDebateId={debateData?.contribute.relatedDebateId}
           />
         )}
       </div>

--- a/src/app/debate-list/[debateId]/page.tsx
+++ b/src/app/debate-list/[debateId]/page.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useState } from 'react';
 import Wrapper from '@/components/Common/Wrapper';
 import { usePathname } from 'next/navigation';
 import PageTitleDescription from '@/components/Common/PageTitleDescription';
-import { Tooltip } from '@chakra-ui/react';
 import { getCommentList } from '@/service/debate/comment';
 import { Debate, getDebateData } from './page.server';
 import CommentList from './components/Comment/CommentList';
@@ -50,40 +49,27 @@ const Page = () => {
     // TODO 페이지 컴포넌트 전체 리팩토링 필요
     <Wrapper>
       <ReturnToDebateList />
-      <Tooltip
-        hasArrow
-        defaultIsOpen
-        arrowSize={10}
-        label="💬 연관 토론 : #11"
-        placement="right-start"
-        color="black"
-        backgroundColor="#f6f6f6"
-        size="lg"
-        padding="0.25rem 0.75rem"
-        mr="1.2rem "
-        mt="0.2rem"
-        rounded="sm"
-      >
-        <div className="w-max">
-          {debateData?.status === 'OPEN' ? (
-            <PageTitleDescription
-              title="토론하기"
-              description="토론에 참여해보세요"
-            />
-          ) : (
-            <PageTitleDescription
-              title="토론결과"
-              description="종료된 토론의 결과를 확인하세요."
-            />
-          )}
-        </div>
-      </Tooltip>
+      <div className="w-max">
+        {debateData?.status === 'OPEN' ? (
+          <PageTitleDescription
+            title="토론하기"
+            description="토론에 참여해보세요"
+            relatedDebateId={debateId}
+          />
+        ) : (
+          <PageTitleDescription
+            title="토론결과"
+            description="종료된 토론의 결과를 확인하세요."
+            relatedDebateId={debateId}
+          />
+        )}
+      </div>
       {isNewReviseRequested ? (
         ''
       ) : (
         <NewReviseRequest
           debateId={debateId}
-          starId={debateData?.documentId}
+          starId={debateData?.contribute.documentId}
           setIsNewReviseRequested={setIsNewReviseRequested}
         />
       )}

--- a/src/app/debate-list/[debateId]/page.tsx
+++ b/src/app/debate-list/[debateId]/page.tsx
@@ -10,7 +10,7 @@ import CommentList from './components/Comment/CommentList';
 import CommentCreate from './components/Comment/CommentCreate';
 import ReturnToDebateList from '../components/ReturnToDebateList';
 import DebateDetail from './components/DebateDetail';
-import NewReviseRequest from './components/NewReviseRequest';
+import NewReviseRequestButton from './components/NewReviseRequest';
 
 const Page = () => {
   const pathname = usePathname();
@@ -67,7 +67,7 @@ const Page = () => {
       {isNewReviseRequested ? (
         ''
       ) : (
-        <NewReviseRequest
+        <NewReviseRequestButton
           debateId={debateId}
           starId={debateData?.contribute.documentId}
           setIsNewReviseRequested={setIsNewReviseRequested}

--- a/src/lib/debate/transTitleAndTagChanged.ts
+++ b/src/lib/debate/transTitleAndTagChanged.ts
@@ -1,0 +1,29 @@
+import { Amendment } from '@/types/common/Amendment';
+
+const transTitleTagtoAmendment = (
+  changedType: 'title' | 'tag',
+  beforeContent: string,
+  afterContent: string,
+): Amendment => {
+  const title = changedType === 'title' ? '글 제목 변경' : '상위계층태그 변경';
+  const content = beforeContent || 'X';
+  const requestedContent = afterContent || 'X';
+
+  return {
+    amendmentId: 0, // 실제 구현에서는 고유 ID 생성 로직이 필요할 수 있음
+    type: 'UPDATE',
+    targetSection: {
+      sectionId: 0, // 실제 구현에서는 적절한 섹션 ID 할당 필요
+      revision: 0,
+      heading: 'H1',
+      title,
+      content,
+    },
+    requestedSectionHeading: 'H1',
+    requestedSectionTitle: title,
+    requestedSectionContent: requestedContent,
+    creatingOrder: 0,
+  };
+};
+
+export default transTitleTagtoAmendment;

--- a/src/lib/debate/transTitleAndTagChanged.ts
+++ b/src/lib/debate/transTitleAndTagChanged.ts
@@ -10,10 +10,10 @@ const transTitleTagtoAmendment = (
   const requestedContent = afterContent || 'X';
 
   return {
-    amendmentId: 0, // 실제 구현에서는 고유 ID 생성 로직이 필요할 수 있음
+    amendmentId: 0,
     type: 'UPDATE',
     targetSection: {
-      sectionId: 0, // 실제 구현에서는 적절한 섹션 ID 할당 필요
+      sectionId: 0,
       revision: 0,
       heading: 'H1',
       title,

--- a/src/types/common/Amendment.ts
+++ b/src/types/common/Amendment.ts
@@ -7,15 +7,38 @@ export interface Contributor {
 export interface Amendment {
   amendmentId: number;
   type: string;
-  targetSection: {
-    sectionId: number;
-    revision: number;
-    heading: string;
-    title: string;
-    content: string;
-  };
+  targetSection: Section;
   requestedSectionHeading: string;
   requestedSectionTitle: string;
   requestedSectionContent: string;
   creatingOrder: number;
+}
+
+interface Section {
+  sectionId: number;
+  revision: number;
+  heading: string;
+  title: string;
+  content: string;
+}
+
+export interface Contribute {
+  contributeId: number;
+  contributeTitle: string;
+  contributeDescription: string;
+  documentId: number;
+  contributor: Contributor;
+  amendments: Amendment[];
+  beforeDocumentTitle: string;
+  afterDocumentTitle: string;
+  beforeParentDocumentId: number;
+  beforeParentDocumentTitle: string;
+  afterParentDocumentId: number;
+  afterParentDocumentTitle: string;
+  contributeStatus: 'VOTING';
+  documentTitle: string;
+  parentDocumentId: number;
+  parentDocumentTitle: string;
+  relatedDebateId: number;
+  endAt: string;
 }


### PR DESCRIPTION
## 변경 내용

- 토론 상세페이지 조회 api 수정 반영하여 타입 및 렌더링 수정
- 토론 제목/상위계층태그 변경 시 수정사항에 추가하여 렌더링

## 특이 사항

- 추후에 백엔드에서 수정요청 가능 상태 정보를 주면 추가 수정 필요

## 체크리스트

-   [x] PR 날리기 전에 develop branch pull 받으셨나요?
-   [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
-   [x] 주석 Comment Anchors 컨벤션에 맞추어 다셨나요?

closes #210 
