### PR TITLE
#255 [feat] 토론 댓글 신고 기능 성공실패 알림 구현

### DIFF
--- a/src/app/debate-list/[debateId]/components/Comments/CommentCard.tsx
+++ b/src/app/debate-list/[debateId]/components/Comments/CommentCard.tsx
@@ -1,8 +1,14 @@
 import React, { Dispatch, SetStateAction, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import ReportModal from '@/components/Common/ReportModal';
-import { deleteComment, updateComment } from '@/service/debate/comment';
-import { Box, useDisclosure } from '@chakra-ui/react';
+import {
+  DeleteCommentArgs,
+  UpdateCommentArgs,
+  deleteComment,
+  updateComment,
+} from '@/service/debate/comment';
+import { Box, useDisclosure, useToast } from '@chakra-ui/react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import EditCommentForm from './CreateComment/EditCommentForm';
 import CommentDisplay from './CreateComment/CommentDisplay';
 
@@ -34,27 +40,77 @@ const CommentCard: React.FC<DebateCommentProps> = ({
   const [isEdit, setIsEdit] = useState<boolean>(false);
   const [updatedComment, setUpdatedComment] = useState<string>(commentContent);
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const toast = useToast();
+  const queryClient = useQueryClient();
 
-  const handleDeleteComment = () => {
-    deleteComment(commentId, debateId);
-    setIsChanged(prev => {
-      return !prev;
-    });
-  };
   const handleEditComment = () => {
     setIsEdit(prev => {
       return !prev;
     });
   };
 
+  const deleteCommentmutation = useMutation<void, Error, DeleteCommentArgs>({
+    mutationFn: deleteComment,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['comments', commentId] });
+      toast({
+        title: `댓글 삭제 성공!`,
+        description: '댓글 삭제에 성공했습니다!',
+        status: 'success',
+        duration: 2000,
+        isClosable: true,
+      });
+      setIsChanged(prev => {
+        return !prev;
+      });
+    },
+    onError: error => {
+      console.error('댓글 삭제 실패: ', error);
+      toast({
+        title: '삭제 실패',
+        description: error.message,
+        status: 'error',
+        duration: 2000,
+        isClosable: true,
+      });
+    },
+  });
+
+  const { mutate: updateCommentMutate } = useMutation<
+    void,
+    Error,
+    UpdateCommentArgs
+  >({
+    mutationFn: updateComment,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['comments', debateId] });
+      setIsChanged(prev => {return !prev});
+      setIsEdit(prev => {return !prev});
+      toast({
+        title: `댓글 수정 성공!`,
+        description: '댓글 수정이 완료되었습니다.',
+        status: 'success',
+        duration: 2000,
+        isClosable: true,
+      });
+    },
+    onError: error => {
+      console.error('댓글 수정 실패: ', error);
+      toast({
+        title: '댓글 수정 실패',
+        description: error.message,
+        status: 'error',
+        duration: 2000,
+        isClosable: true,
+      });
+    },
+  });
+  const handleDeleteComment = () => {
+    deleteCommentmutation.mutate({ commentId, debateId });
+  };
+
   const handleUpdateComment = () => {
-    updateComment(commentId, updatedComment, debateId);
-    setIsChanged(prev => {
-      return !prev;
-    });
-    setIsEdit(prev => {
-      return !prev;
-    });
+    updateCommentMutate({ commentId, newContent: updatedComment, debateId });
   };
 
   return (
@@ -62,7 +118,7 @@ const CommentCard: React.FC<DebateCommentProps> = ({
       <ReportModal
         isOpen={isOpen}
         onClose={onClose}
-        title="comment"
+        type="comment"
         dataId={commentId}
       />
       {isEdit ? (

--- a/src/app/stars/[starId]/components/StarInfo.tsx
+++ b/src/app/stars/[starId]/components/StarInfo.tsx
@@ -113,7 +113,7 @@ const StarInfo = ({
       <ReportModal
         isOpen={isOpen}
         onClose={onClose}
-        title="document"
+        type="document"
         dataId={starId}
       />
       <div className="flex flex-col">

--- a/src/service/debate/comment.ts
+++ b/src/service/debate/comment.ts
@@ -30,15 +30,22 @@ export const postNewComment = async (newContent: string, debateId: number) => {
     return response.data;
   } catch (error) {
     console.error('댓글 생성 중 오류 발생:', error);
-    throw error;
+    throw Error('댓글 생성 실패');
   }
 };
+
+export interface UpdateCommentArgs {
+  commentId: number;
+  newContent: string;
+  debateId: number;
+}
+
 // NOTE 댓글 수정
-export const updateComment = async (
-  commentId: number,
-  newContent: string,
-  debateId: number,
-) => {
+export const updateComment = async ({
+  commentId,
+  newContent,
+  debateId,
+}: UpdateCommentArgs): Promise<any> => {
   try {
     const response = await apiClient.patch(
       `/api/debates/${debateId}/comments/${commentId}`,
@@ -49,20 +56,24 @@ export const updateComment = async (
     return response.data;
   } catch (error) {
     console.error('댓글 수정 중 오류 발생:', error);
-    throw error;
+    throw new Error('댓글 수정 실패');
   }
 };
 
+export interface DeleteCommentArgs {
+  commentId: number;
+  debateId: number;
+}
+
 // NOTE 댓글 삭제
-export const deleteComment = async (
-  commentId: number,
-  debateId: number,
-): Promise<boolean> => {
+export const deleteComment = async ({
+  commentId,
+  debateId,
+}: DeleteCommentArgs): Promise<void> => {
   try {
     await apiClient.delete(`/api/debates/${debateId}/comments/${commentId}`);
-    return true;
   } catch (error) {
     console.error('댓글 삭제 중 오류 발생:', error);
-    throw error;
+    throw new Error('댓글 삭제 실패');
   }
 };


### PR DESCRIPTION
## 변경 내용

- 신고 기능 성공/실패 알림 구현
- 신고 컨텐츠 글 0자일때 실패 예외 처리
- 토론 댓글 삭제, 수정 성공/실패 알림 구현 
- 토론 댓글 react-query 적용

## 특이 사항

- 추후 toast 컴포넌트 통일 필요

## 체크리스트

-   [x] PR 날리기 전에 develop branch pull 받으셨나요?
-   [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
-   [x] 주석 Comment Anchors 컨벤션에 맞추어 다셨나요?

closes #255 
