### PR TITLE
#295 [style] 헤더 반응형

### DIFF
--- a/src/components/Header/DebateButton.tsx
+++ b/src/components/Header/DebateButton.tsx
@@ -1,11 +1,14 @@
+'use client';
+
 import { Button } from '@chakra-ui/react';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 import { AiOutlineComment } from 'react-icons/ai';
 
-const DebateButton = () => {
+const DebateButton = ({ onClose }: { onClose: () => void }) => {
   const router = useRouter();
   const handleClickDebate = () => {
+    onClose();
     router.push('/debate-list');
   };
   return (

--- a/src/components/Header/DebateButton.tsx
+++ b/src/components/Header/DebateButton.tsx
@@ -13,7 +13,7 @@ const DebateButton = ({ onClose }: { onClose: () => void }) => {
   };
   return (
     <Button
-      leftIcon={<AiOutlineComment />}
+      leftIcon={<AiOutlineComment size="20px" />}
       variant="ghost"
       textColor="white"
       _hover={{ bg: '#ebedf0', textColor: 'black', fontWeight: 600 }}

--- a/src/components/Header/DebateButton.tsx
+++ b/src/components/Header/DebateButton.tsx
@@ -1,0 +1,28 @@
+import { Button } from '@chakra-ui/react';
+import { useRouter } from 'next/navigation';
+import React from 'react';
+import { AiOutlineComment } from 'react-icons/ai';
+
+const DebateButton = () => {
+  const router = useRouter();
+  const handleClickDebate = () => {
+    router.push('/debate-list');
+  };
+  return (
+    <Button
+      leftIcon={<AiOutlineComment />}
+      variant="ghost"
+      textColor="white"
+      _hover={{ bg: '#ebedf0', textColor: 'black', fontWeight: 600 }}
+      cursor="pointer"
+      size="sm"
+      rounded="sm"
+      justifyContent="flex-start"
+      onClick={handleClickDebate}
+    >
+      <h2 className="text-md text-semibold ">토론</h2>
+    </Button>
+  );
+};
+
+export default DebateButton;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -50,20 +50,20 @@ const Header = () => {
                 <DrawerCloseButton />
               </DrawerHeader>
               <DrawerBody className="flex flex-col bg-[#212121]">
-                <VoteButton />
-                <DebateButton />
-                <NewStarButton />
+                <VoteButton onClose={onClose} />
+                <DebateButton onClose={onClose} />
+                <NewStarButton onClose={onClose} />
               </DrawerBody>
             </DrawerContent>
           </Drawer>
         </div>
         <div className="mobile:hidden desktop:flex">
-          <Navigation />
+          <Navigation onClose={onClose} />
         </div>
         <Logo />
         <div className="flex flex-row items-center">
           <div className="mobile: hidden desktop:flex">
-            <NewStarButton />
+            <NewStarButton onClose={onClose} />
           </div>
           <Login />
         </div>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,22 +1,73 @@
-import React from 'react';
-import { Box } from '@chakra-ui/react';
+import React, { useRef } from 'react';
+import {
+  Button,
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
+  useDisclosure,
+} from '@chakra-ui/react';
+import { IoMenu } from 'react-icons/io5';
 import Navigation from './LeftNav';
 import Login from './RightNav';
 import Logo from './Logo';
+import NewStarButton from './NewStarButton';
+import VoteButton from './VoteButton';
+import DebateButton from './DebateButton';
 
 const Header = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const btnRef = useRef<HTMLButtonElement>(null);
   return (
-    <div className="flex w-full h-16 bg-[#212121] border-b border-gray-500/20 text-white justify-center sticky top-0 z-10">
-      <Box
-        display="flex"
-        width="80rem"
-        justifyItems="space-between"
-        className="flex-row h-16 justify-between items-center"
-      >
-        <Navigation />
+    <div className="flex w-full h-16 bg-[#212121] border-b border-gray-500/20 text-white justify-center sticky top-0 z-10 ">
+      <div className="flex flex-row h-16 w-[80rem] justify-between items-center">
+        <div className="mobile:flex desktop:hidden mobile:ml-4">
+          <Button
+            ref={btnRef}
+            onClick={onOpen}
+            bgColor="transparent"
+            color="white"
+            fontSize="2xl"
+            _hover={{
+              bgColor: 'transparent',
+              color: 'white',
+            }}
+          >
+            <IoMenu />
+          </Button>
+          <Drawer
+            isOpen={isOpen}
+            placement="left"
+            onClose={onClose}
+            finalFocusRef={btnRef}
+          >
+            <DrawerOverlay />
+            <DrawerContent>
+              <DrawerHeader className="bg-[#212121] text-white">
+                메뉴
+                <DrawerCloseButton />
+              </DrawerHeader>
+              <DrawerBody className="flex flex-col bg-[#212121]">
+                <VoteButton />
+                <DebateButton />
+                <NewStarButton />
+              </DrawerBody>
+            </DrawerContent>
+          </Drawer>
+        </div>
+        <div className="mobile:hidden desktop:flex">
+          <Navigation />
+        </div>
         <Logo />
-        <Login />
-      </Box>
+        <div className="flex flex-row items-center">
+          <div className="mobile: hidden desktop:flex">
+            <NewStarButton />
+          </div>
+          <Login />
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/Header/LeftNav.tsx
+++ b/src/components/Header/LeftNav.tsx
@@ -4,7 +4,7 @@ import DebateButton from './DebateButton';
 
 const LeftNav = ({ onClose }: { onClose: () => void }) => {
   return (
-    <div className="flex mobile:flex-col desktop:flex-row mobile:ml-4 desktop:ml-20 w-40">
+    <div className="flex gap-2 mobile:flex-col desktop:flex-row mobile:ml-4 desktop:ml-20 w-40">
       <VoteButton onClose={onClose} />
       <DebateButton onClose={onClose} />
     </div>

--- a/src/components/Header/LeftNav.tsx
+++ b/src/components/Header/LeftNav.tsx
@@ -1,41 +1,12 @@
-import { Button } from '@chakra-ui/react';
-import Link from 'next/link';
 import React from 'react';
-import { AiOutlineComment, AiOutlineLike } from 'react-icons/ai';
+import VoteButton from './VoteButton';
+import DebateButton from './DebateButton';
 
 const LeftNav = () => {
   return (
-    <div className="flex ml-20 w-40">
-      <div className="inline mr-4">
-        <Link href="/vote-list">
-          <Button
-            leftIcon={<AiOutlineLike size="20px" />}
-            variant="ghost"
-            textColor="white"
-            _hover={{ bg: '#ebedf0', textColor: 'black', fontWeight: 600 }}
-            cursor="pointer"
-            size="sm"
-            rounded="sm"
-          >
-            <h2 className="text-md text-semibold">투표</h2>
-          </Button>
-        </Link>
-      </div>
-      <div className="inline">
-        <Link href="/debate-list">
-          <Button
-            leftIcon={<AiOutlineComment size="20px" />}
-            variant="ghost"
-            textColor="white"
-            _hover={{ bg: '#ebedf0', textColor: 'black', fontWeight: 600 }}
-            cursor="pointer"
-            size="sm"
-            rounded="sm"
-          >
-            <h2 className="text-md text-semibold">토론</h2>
-          </Button>
-        </Link>
-      </div>
+    <div className="flex mobile:flex-col desktop:flex-row mobile:ml-4 desktop:ml-20 w-40">
+      <VoteButton />
+      <DebateButton />
     </div>
   );
 };

--- a/src/components/Header/LeftNav.tsx
+++ b/src/components/Header/LeftNav.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import VoteButton from './VoteButton';
 import DebateButton from './DebateButton';
 
-const LeftNav = () => {
+const LeftNav = ({ onClose }: { onClose: () => void }) => {
   return (
     <div className="flex mobile:flex-col desktop:flex-row mobile:ml-4 desktop:ml-20 w-40">
-      <VoteButton />
-      <DebateButton />
+      <VoteButton onClose={onClose} />
+      <DebateButton onClose={onClose} />
     </div>
   );
 };

--- a/src/components/Header/NewStarButton.tsx
+++ b/src/components/Header/NewStarButton.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { HiOutlinePencil } from 'react-icons/hi';
 import { useRecoilValue } from 'recoil';
 
-const NewStarButton = () => {
+const NewStarButton = ({ onClose }: { onClose: () => void }) => {
   const isLogin = useRecoilValue(loginState);
   const toast = useToast();
   const router = useRouter();
@@ -17,8 +17,10 @@ const NewStarButton = () => {
         isClosable: true,
         status: 'warning',
       });
+      onClose();
       router.push('/login');
     } else {
+      onClose();
       router.push('/new-star');
     }
   };

--- a/src/components/Header/NewStarButton.tsx
+++ b/src/components/Header/NewStarButton.tsx
@@ -1,0 +1,42 @@
+import { loginState } from '@/store/user/login';
+import { Button, useToast } from '@chakra-ui/react';
+import { useRouter } from 'next/navigation';
+import React from 'react';
+import { HiOutlinePencil } from 'react-icons/hi';
+import { useRecoilValue } from 'recoil';
+
+const NewStarButton = () => {
+  const isLogin = useRecoilValue(loginState);
+  const toast = useToast();
+  const router = useRouter();
+  const handleCheckLogin = () => {
+    if (!isLogin.isLoggedIn) {
+      toast({
+        title: '로그인이 필요합니다.',
+        duration: 2000,
+        isClosable: true,
+        status: 'warning',
+      });
+      router.push('/login');
+    } else {
+      router.push('/new-star');
+    }
+  };
+  return (
+    <Button
+      leftIcon={<HiOutlinePencil size="20px" />}
+      variant="ghost"
+      textColor="white"
+      _hover={{ bg: '#ebedf0', textColor: 'black', fontWeight: 600 }}
+      cursor="pointer"
+      size="sm"
+      rounded="sm"
+      justifyContent="flex-start"
+      onClick={handleCheckLogin}
+    >
+      <h2 className="text-md text-semibold">별생성</h2>
+    </Button>
+  );
+};
+
+export default NewStarButton;

--- a/src/components/Header/RightNav.tsx
+++ b/src/components/Header/RightNav.tsx
@@ -21,7 +21,6 @@ import { useRouter } from 'next/navigation';
 import React, { useEffect, useRef, useState } from 'react';
 import { AiOutlineLogin, AiOutlineLogout } from 'react-icons/ai';
 import { FaBell, FaUser } from 'react-icons/fa';
-import { HiOutlinePencil } from 'react-icons/hi';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import countNotification from '@/store/notification/countNotification';
 import {
@@ -111,20 +110,6 @@ const RightNav = () => {
     logoutMutation.mutate();
   };
 
-  const handleCheckLogin = () => {
-    if (!isLogin.isLoggedIn) {
-      toast({
-        title: '로그인이 필요합니다.',
-        duration: 2000,
-        isClosable: true,
-        status: 'warning',
-      });
-      router.push('/login');
-    } else {
-      router.push('/new-star');
-    }
-  };
-
   // FIXME 임시 내용, 추후 폴백 컨텐츠로 변경
   if (isError) {
     console.log('error');
@@ -178,22 +163,7 @@ const RightNav = () => {
   }, [isNotificationOpen]);
 
   return (
-    <div className="flex mr-20 w-40 justify-end place-items-center">
-      <div className="inline mr-4 relative">
-        <Button
-          leftIcon={<HiOutlinePencil size="20px" />}
-          variant="ghost"
-          textColor="white"
-          _hover={{ bg: '#ebedf0', textColor: 'black', fontWeight: 600 }}
-          cursor="pointer"
-          size="sm"
-          rounded="sm"
-          onClick={handleCheckLogin}
-        >
-          <h2 className="text-md text-semibold">별생성</h2>
-        </Button>
-      </div>
-
+    <div className="flex mobile:mr-4 desktop:mr-20">
       {/* NOTE 로그인 상태라면 미니프로필 & 로그아웃 버튼, 아니라면 로그인 버튼 */}
       {userData && isLogin.isLoggedIn ? (
         <div className="flex flex-row gap-0">

--- a/src/components/Header/RightNav.tsx
+++ b/src/components/Header/RightNav.tsx
@@ -16,7 +16,6 @@ import {
   useToast,
 } from '@chakra-ui/react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import React, { useEffect, useRef, useState } from 'react';
 import { AiOutlineLogin, AiOutlineLogout } from 'react-icons/ai';
@@ -117,6 +116,11 @@ const RightNav = () => {
   if (isLoading) {
     console.log('loading');
   }
+
+  // NOTE 로그인 버튼
+  const handleClickLogin = () => {
+    router.push('/login');
+  };
 
   // NOTE 유저 정보 모달
   const [userModalPosition, setUserModalPosition] = useState({
@@ -261,19 +265,26 @@ const RightNav = () => {
         <div>
           <Tooltip
             hasArrow
-            defaultIsOpen
             arrowSize={10}
             label="우주로 출발하기🚀"
-            placement="right"
+            placement="bottom"
             color="black"
             backgroundColor="#f6f6f6"
             size="lg"
             padding="0.25rem 0.75rem"
             rounded="sm"
           >
-            <Link href="/login">
-              <AiOutlineLogin className="w-6 h-6" />
-            </Link>
+            <Button
+              bgColor="transparent"
+              color="white"
+              _hover={{
+                bgColor: 'transparent',
+                color: 'white',
+              }}
+              onClick={handleClickLogin}
+            >
+              <AiOutlineLogin size="24px" />
+            </Button>
           </Tooltip>
         </div>
       )}

--- a/src/components/Header/RightNav.tsx
+++ b/src/components/Header/RightNav.tsx
@@ -6,6 +6,11 @@ import { ResponseType } from '@/types/common/ResponseType';
 import {
   Avatar,
   Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
   Tooltip,
   useDisclosure,
   useToast,
@@ -15,7 +20,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import React, { useEffect, useRef, useState } from 'react';
 import { AiOutlineLogin, AiOutlineLogout } from 'react-icons/ai';
-import { FaBell } from 'react-icons/fa';
+import { FaBell, FaUser } from 'react-icons/fa';
 import { HiOutlinePencil } from 'react-icons/hi';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import countNotification from '@/store/notification/countNotification';
@@ -90,12 +95,19 @@ const RightNav = () => {
     },
   });
 
+  // NOTE 유저 메뉴 열기
+  const handleOpenUserMenu = () => {
+    onUserMenuOpen();
+  };
+
   // NOTE 마이페이지로 이동
   const handleClickMypage = () => {
+    onUserMenuClose();
     router.push('/mypage');
   };
   // NOTE 로그아웃 mutation 함수 호출
   const handleLogout = () => {
+    onUserMenuClose();
     logoutMutation.mutate();
   };
 
@@ -121,20 +133,49 @@ const RightNav = () => {
     console.log('loading');
   }
 
-  // NOTE 알림 모달
-  const { isOpen, onOpen, onClose } = useDisclosure();
-  const [modalPosition, setModalPosition] = useState({ top: 0, left: 0 });
-  const buttonRef = useRef<HTMLButtonElement>(null);
-
+  // NOTE 유저 정보 모달
+  const [userModalPosition, setUserModalPosition] = useState({
+    top: 0,
+    left: 0,
+  });
+  const userButtonRef = useRef<HTMLButtonElement>(null);
+  const {
+    isOpen: isUserMenuOpen,
+    onOpen: onUserMenuOpen,
+    onClose: onUserMenuClose,
+  } = useDisclosure();
   useEffect(() => {
-    if (isOpen && buttonRef.current) {
-      const buttonRect = buttonRef.current.getBoundingClientRect();
-      setModalPosition({
-        top: buttonRect.bottom - 64,
-        left: buttonRect.left - 250,
+    if (isUserMenuOpen && userButtonRef.current) {
+      const userButtonRect = userButtonRef.current.getBoundingClientRect();
+      setUserModalPosition({
+        top: userButtonRect.bottom - 55,
+        left: userButtonRect.left - 130,
       });
     }
-  }, [isOpen]);
+  }, [isUserMenuOpen]);
+
+  // NOTE 알림 모달
+  const [notiModalPosition, setNotiModalPosition] = useState({
+    top: 0,
+    left: 0,
+  });
+  const notiButtonRef = useRef<HTMLButtonElement>(null);
+
+  const {
+    isOpen: isNotificationOpen,
+    onOpen: onNotificationOpen,
+    onClose: onNotificationClose,
+  } = useDisclosure();
+
+  useEffect(() => {
+    if (isNotificationOpen && notiButtonRef.current) {
+      const notiButtonRect = notiButtonRef.current.getBoundingClientRect();
+      setNotiModalPosition({
+        top: notiButtonRect.bottom - 64,
+        left: notiButtonRect.left - 270,
+      });
+    }
+  }, [isNotificationOpen]);
 
   return (
     <div className="flex mr-20 w-40 justify-end place-items-center">
@@ -155,16 +196,16 @@ const RightNav = () => {
 
       {/* NOTE 로그인 상태라면 미니프로필 & 로그아웃 버튼, 아니라면 로그인 버튼 */}
       {userData && isLogin.isLoggedIn ? (
-        <div className="flex flex-row gap-4">
+        <div className="flex flex-row gap-0">
           <Button
-            onClick={onOpen}
+            onClick={onNotificationOpen}
             bgColor="transparent"
             color="white"
             fontSize="2xl"
             _hover={{
               bgColor: 'transparent',
             }}
-            ref={buttonRef}
+            ref={notiButtonRef}
             position="relative"
           >
             <FaBell />
@@ -173,46 +214,78 @@ const RightNav = () => {
             )}
           </Button>
           <Notification
-            isOpen={isOpen}
-            onClose={onClose}
-            position={modalPosition}
+            isOpen={isNotificationOpen}
+            onClose={onNotificationClose}
+            position={notiModalPosition}
           />
           <Button
             variant="link"
             gap={2}
             color="white"
             alignSelf="center"
-            onClick={handleClickMypage}
+            position="relative"
+            ref={userButtonRef}
+            onClick={handleOpenUserMenu}
           >
             <Avatar
               name={userData?.results.nickname}
               src={userData?.results.profileImgUrl}
-              size="xs"
+              size="sm"
             />
-            <h3 className="text-sm self-center">
-              {userData?.results.nickname}
-            </h3>
           </Button>
-          <Tooltip
-            hasArrow
-            arrowSize={10}
-            label="지구로 돌아가기🌍"
-            placement="right"
-            color="black"
-            backgroundColor="#f6f6f6"
-            size="lg"
-            padding="0.25rem 0.75rem"
-            rounded="sm"
-          >
-            <Button
-              variant="link"
-              color="white"
-              alignSelf="center"
-              onClick={handleLogout}
+          <Modal onClose={onUserMenuClose} isOpen={isUserMenuOpen}>
+            <ModalOverlay bgColor="transparent" />
+            <ModalContent
+              position="absolute"
+              top={`${userModalPosition.top}px`}
+              left={`${userModalPosition.left}px`}
+              bgColor="#2e2e2e"
+              width="11rem"
+              borderWidth={2}
+              borderColor="#292929"
+              rounded="lg"
             >
-              <AiOutlineLogout className="w-6 h-6" />
-            </Button>
-          </Tooltip>
+              <ModalHeader paddingX="1rem" paddingY="0.5rem">
+                <div className="flex flex-row gap-2 items-center">
+                  <Avatar
+                    name={userData?.results.nickname}
+                    src={userData?.results.profileImgUrl}
+                    size="xs"
+                  />
+                  <h4 className="text-white text-sm text-center">
+                    <span className="text-primary-dark-200">
+                      {userData.results.nickname}
+                    </span>{' '}
+                    님 👋
+                  </h4>
+                </div>
+              </ModalHeader>
+              <ModalBody paddingX="1rem">
+                <div className="flex flex-col gap-3 items-start">
+                  <Button
+                    variant="link"
+                    size="sm"
+                    color="white"
+                    borderBottom="1"
+                    borderColor="white"
+                    leftIcon={<FaUser />}
+                    onClick={handleClickMypage}
+                  >
+                    마이페이지
+                  </Button>
+                  <Button
+                    variant="link"
+                    size="sm"
+                    color="white"
+                    leftIcon={<AiOutlineLogout />}
+                    onClick={handleLogout}
+                  >
+                    지구로 돌아가기
+                  </Button>
+                </div>
+              </ModalBody>
+            </ModalContent>
+          </Modal>
         </div>
       ) : (
         <div>

--- a/src/components/Header/VoteButton.tsx
+++ b/src/components/Header/VoteButton.tsx
@@ -1,0 +1,28 @@
+import { Button } from '@chakra-ui/react';
+import { useRouter } from 'next/navigation';
+import React from 'react';
+import { AiOutlineLike } from 'react-icons/ai';
+
+const VoteButton = () => {
+  const router = useRouter();
+  const handleClickVote = () => {
+    router.push('/vote-list');
+  };
+  return (
+    <Button
+      leftIcon={<AiOutlineLike />}
+      variant="ghost"
+      textColor="white"
+      _hover={{ bg: '#ebedf0', textColor: 'black', fontWeight: 600 }}
+      cursor="pointer"
+      size="sm"
+      rounded="sm"
+      justifyContent="flex-start"
+      onClick={handleClickVote}
+    >
+      <h2 className="text-md text-semibold">투표</h2>
+    </Button>
+  );
+};
+
+export default VoteButton;

--- a/src/components/Header/VoteButton.tsx
+++ b/src/components/Header/VoteButton.tsx
@@ -13,7 +13,7 @@ const VoteButton = ({ onClose }: { onClose: () => void }) => {
   };
   return (
     <Button
-      leftIcon={<AiOutlineLike />}
+      leftIcon={<AiOutlineLike size="20px" />}
       variant="ghost"
       textColor="white"
       _hover={{ bg: '#ebedf0', textColor: 'black', fontWeight: 600 }}

--- a/src/components/Header/VoteButton.tsx
+++ b/src/components/Header/VoteButton.tsx
@@ -1,11 +1,14 @@
+'use client';
+
 import { Button } from '@chakra-ui/react';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 import { AiOutlineLike } from 'react-icons/ai';
 
-const VoteButton = () => {
+const VoteButton = ({ onClose }: { onClose: () => void }) => {
   const router = useRouter();
   const handleClickVote = () => {
+    onClose();
     router.push('/vote-list');
   };
   return (

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,7 +18,7 @@ const config: Config = {
       },
       screens: {
         mobile: '0rem',
-        desktop: '62rem',
+        desktop: '48rem',
       },
       colors: {
         background: {


### PR DESCRIPTION
## 변경 내용

- 헤더 프로필 사진, 닉네임, 로그아웃 버튼을 모달로 변경
  - 해당 모달은 프로필 사진을 클릭했을 때 열립니다.
- 헤더 반응형 설정
  - 768px 이하일 때 투표, 토론, 별 생성이 Drawer에 포함되고 햄버거 버튼으로 열 수 있음

## 특이 사항

- 반응형을 설정하기 위해서 LeftNav, RightNav를 리팩토링(컴포넌트 분리) 했습니다.
- 급하게 기능을 추가하느라 코드가 좀 배드 스멜이 납니다🥲 (props drilling) 추후 리팩토링 하도록 하겠습니다.

## 체크리스트

-   [x] PR 날리기 전에 develop branch pull 받으셨나요?
-   [x] 다른 담당자 파일을 수정한 부분에 대해서 이야기 하셨나요?
-   [x] 주석 Comment Anchors 컨벤션에 맞추어 다셨나요?

closes #295 
